### PR TITLE
Set the wordPattern in the language configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 0.6.2
+
+Consider angle brackets and parenthesis when completing unicode symbols.
+
 ### 0.6.0
 
 Bug fixes, stability, and a handful of feature improvements

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,14 @@ export function activate(context: vscode.ExtensionContext) {
                 LEAN_MODE, new LeanInputCompletionProvider(json), '\\'));
     });
 
+    // Load the language-configuration manually, so that we can set the wordPattern.
+    loadJsonFile(context.asAbsolutePath("language-configuration.json")).then(json => {
+        json.wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\/\?\s]+)/g;
+        context.subscriptions.push(
+            vscode.languages.setLanguageConfiguration(LEAN_MODE, json)
+        );
+    })
+    
     // Register support for definition support.
     context.subscriptions.push(
         vscode.languages.registerDefinitionProvider(


### PR DESCRIPTION
Removes some comments from language-configuration.json due to it now being
parsed without comment stripping.

I've tested this locally, with \<. It should be easy to "add" more characters by removing things from the `[^...]` in the wordPattern.