### PR TITLE
Fix language-configuration.json

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -12,7 +12,6 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        // { "open": "'", "close": "'", "notIn": ["string", "comment"] },
         { "open": "/**", "close": " */", "notIn": ["string"] }
     ],
     "surroundingPairs": [
@@ -20,9 +19,5 @@
         ["[", "]"],
         ["(", ")"],
         ["<", ">"]
-        // ["'", "'"]
     ]
-    // this doesn't work right now: (https://github.com/Microsoft/vscode/issues/14221)"
-    // wordPattern" : ""
-    // we must set it programatically
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,7 +136,7 @@ export function activate(context: vscode.ExtensionContext) {
     loadJsonFile(context.asAbsolutePath("language-configuration.json")).then(json => {
         json.wordPattern = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\$\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\/\?\s]+)/g;
         context.subscriptions.push(
-            vscode.languages.setLanguageConfiguration(LEAN_MODE, json)
+            vscode.languages.setLanguageConfiguration(LEAN_MODE.language, json)
         );
     })
     


### PR DESCRIPTION
The JSON file was not valid JSON (because of the comments), also the call to
setLanguageConfiguration was not well-typed (it expects a string, not a
DocumentFilter).