### PR TITLE
Set source in diagnostics: goto erro shows multiline errors

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -35,8 +35,10 @@ export class LeanDiagnosticsProvider implements Disposable {
             const range = new Range(pos, pos);
             let diagnostics = diagnosticMap.get(message.file_name);
             if (!diagnostics) diagnosticMap.set(message.file_name, diagnostics = []);
-            diagnostics.push(new Diagnostic(range, message.text,
-                toSeverity(message.severity)));
+            const d = new Diagnostic(range, message.text,
+                toSeverity(message.severity));
+            d.source = 'Lean';
+            diagnostics.push(d);
         }
 
         this.collection.clear();


### PR DESCRIPTION
I'm not sure if this is a bug in vscode, but attaching a source to the error
message changes the inline diagnostic message to show more than just the first
line, see https://github.com/Microsoft/vscode/blob/master/src/vs/editor/contrib/gotoError/browser/gotoError.ts#L204

With this `F8` and `Shift-F8` show now a multi-line error.

![correct go to error](https://user-images.githubusercontent.com/5176109/27262672-a8e7afe0-5429-11e7-95d3-fafca0c43552.png)
