### PR TITLE
Add explicit pause/continue button in infoview; remove underlines from links

### DIFF
--- a/media/continue.svg
+++ b/media/continue.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" viewBox="0 0 16 16">
+  <path style="fill:#388A34" d="M1 2v12l8-6-8-6z" />
+</svg>

--- a/media/infoview-ctrl.js
+++ b/media/infoview-ctrl.js
@@ -116,12 +116,26 @@ function onPosition(rpos) {
   }
 }
 
-function onStop() {
-  const e = document.createElement("div");
-  e.setAttribute("id", "stopped");
-  e.innerText = "(stopped updating)"
-  document.body.appendChild(e);
+function onPause() {
+  document.getElementById("state-pause").classList.add("disabled");
+  document.getElementById("state-continue").classList.remove("disabled");
 }
+
+function onContinue() {
+  document.getElementById("state-pause").classList.remove("disabled");
+  document.getElementById("state-continue").classList.add("disabled");
+}
+
+window.addEventListener('message', (event => {
+  if (event.data.command == 'position') {
+    onPosition({line: event.data.line, column: event.data.column});
+    onContinue();
+  } else if (event.data.command == 'pause') {
+    onPause();
+  } else if (event.data.command == 'continue') {
+    onContinue();
+  }
+}), false);
 
 function setupHover() {
   const msgs = document.getElementsByClassName("message");
@@ -145,18 +159,11 @@ function setupHover() {
   }
 }
 
-window.addEventListener('message', (event => {
-  if (event.data.command == 'position') {
-    onPosition({line: event.data.line, column: event.data.column});
-  } else if (event.data.command == 'stop') {
-    onStop();
-  }
-}), false);
-
 function onLoad() {
   if (document.body.hasAttribute("data-messages")) {
     onPosition(getPosition(document.body)); // current editor position is stored in body element
   }
+  document.getElementById("state-continue").classList.add("disabled");
   setupHover();
   /* document.getElementById(ID_DEBUG).style.visibility = "visible"; */
 }

--- a/media/infoview.css
+++ b/media/infoview.css
@@ -35,13 +35,31 @@ h1
   font-size: 100%;
 }
 
-div#stopped {
+a {
+  text-decoration: none;
+}
+
+div#run-state {
   display: block;
   position: fixed;
   top: 0px;
   right: 0px;
-  width: auto; /* overwrite regular div */
+  width: auto;
+  padding: 3px 5px 1px 7px;
   z-index: 2;
+}
+
+div#run-state span {
+  vertical-align: middle;
+}
+
+div#run-state span a img {
+  position: relative;
+  top: 3px;
+}
+
+.disabled {
+  display: none;
 }
 
 #marker {
@@ -77,6 +95,10 @@ div.information h1 a {
   color: darkgreen;
 }
 
+div#run-state {
+  background-color: #f0f0f0;
+}
+
 /* Theme categories, set by VS Code in the body element:
 - vscode-light
 - vscode-dark
@@ -110,6 +132,10 @@ div.information h1 a {
   color: lightgreen;
 }
 
+.vscode-dark div#run-state {
+  background-color: #222;
+}
+
 
 .vscode-high-contrast h1 {
   border-bottom-color: white;
@@ -137,5 +163,9 @@ div.information h1 a {
 
 .vscode-high-contrast div.information h1 {
   color: lightgreen;
+}
+
+.vscode-high-contrast div#run-state {
+  background-color: #000;
 }
 

--- a/media/pause.svg
+++ b/media/pause.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="16" height="16" viewBox="0 0 16 16">
+  <g style="fill:#00539C">
+    <rect width="4" height="12" x="2"  y="2" />
+    <rect width="4" height="12" x="10" y="2" />
+  </g>
+</svg>

--- a/media/stop-updating-dark.svg
+++ b/media/stop-updating-dark.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="18" height="18" viewBox="0 0 18 18">
-  <g style="fill:#ffffff">
-    <rect width="4" height="14" x="4" y="2" />
-    <rect width="4" height="14" x="9" y="2" />
-  </g>
-</svg>

--- a/media/stop-updating-light.svg
+++ b/media/stop-updating-light.svg
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="18" height="18" viewBox="0 0 18 18">
-  <g style="fill:#000000">
-    <rect width="4" height="14" x="4" y="2" />
-    <rect width="4" height="14" x="9" y="2" />
-  </g>
-</svg>

--- a/package.json
+++ b/package.json
@@ -81,15 +81,6 @@
                 }
             },
             {
-                "command": "lean.stopUpdating",
-                "category": "Lean",
-                "title": "Info View: Stop Updating",
-                "icon":{
-                    "dark": "./media/stop-updating-dark.svg",
-                    "light": "./media/stop-updating-light.svg"
-                }
-            },
-            {
                 "command": "lean.infoView.displayGoal",
                 "category": "Lean",
                 "title": "Info View: Display Goal",
@@ -107,15 +98,6 @@
                 "icon":{
                     "dark": "./media/display-list-dark.svg",
                     "light": "./media/display-list-light.svg"
-                }
-            },
-            {
-                "command": "lean.infoView.stopUpdating",
-                "category": "Lean",
-                "title": "Info View: Stop Updating",
-                "icon":{
-                    "dark": "./media/stop-updating-dark.svg",
-                    "light": "./media/stop-updating-light.svg"
                 }
             },
             {
@@ -222,10 +204,6 @@
                 {
                     "command": "lean.infoView.displayList",
                     "when": "resourceSchema == lean-info"
-                },
-                {
-                    "command": "lean.infoView.stopUpdating",
-                    "when": "resourceSchema == lean-info"
                 }
             ],
             "editor/title": [
@@ -240,22 +218,12 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "lean.stopUpdating",
-                    "when": "editorLangId == lean",
-                    "group": "navigation"
-                },
-                {
                     "command": "lean.infoView.displayList",
                     "when": "resourceScheme == lean-info",
                     "group": "navigation"
                 },
                 {
                     "command": "lean.infoView.displayGoal",
-                    "when": "resourceScheme == lean-info",
-                    "group": "navigation"
-                },
-                {
-                    "command": "lean.infoView.stopUpdating",
                     "when": "resourceScheme == lean-info",
                     "group": "navigation"
                 }


### PR DESCRIPTION
Two small changes:
* the stop button in the editor header moved to the infoview and toggles between pause/continue; this time the state change is visible
* remove underlines from `<a>` elements