### PR TITLE
fix two syntax highlighting examples from zulip

### DIFF
--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -14,7 +14,7 @@
         {"include": "#definitionName"},
         {"match": ","}
       ],
-      "end": "(?=\\bwith\\b|[:\\|\\(\\[\\{⦃<>])",
+      "end": "(?=\\bwith\\b|\\bextends\\b|[:\\|\\(\\[\\{⦃<>])",
       "name": "meta.definitioncommand.lean"
     },
     { "match": "\\b(Prop|Type|Sort)\\b", "name": "storage.type.lean" },
@@ -28,7 +28,7 @@
     { "match": "#print\\s+(def|definition|inductive|instance|structure|axiom|axioms|class)\\b", "name": "keyword.other.command.lean" },
     { "match": "#(print|eval|reduce|check|help|exit)\\b", "name": "keyword.other.command.lean" },
     {
-      "match": "\\b(?<!\\.)(import|prelude|theory|definition|def|abbreviation|instance|renaming|hiding|exposing|parameter|parameters|begin|constant|constants|lemma|variable|variables|theorem|example|open|axiom|inductive|coinductive|with|structure|universe|universes|alias|precedence|reserve|postfix|prefix|infix|infixl|infixr|notation|end|using|namespace|section|local|set_option|extends|include|omit|class|classes|instances|raw|run_cmd)\\b",
+      "match": "\\b(?<!\\.)(import|prelude|theory|definition|def|abbreviation|instance|renaming|hiding|exposing|parameter|parameters|begin|constant|constants|lemma|variable|variables|theorem|example|open|axiom|inductive|coinductive|with|structure|universe|universes|alias|precedence|reserve|postfix|prefix|infix|infixl|infixr|notation|end|using|namespace|section|local|set_option|extends|include|omit|class|classes|instances|raw|run_cmd)(?!\\.)\\b",
       "name": "keyword.other.lean"
     },
     {

--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -32,7 +32,7 @@
       "name": "keyword.other.lean"
     },
     {
-      "match": "\\b(?<!\\.)(calc|have|this|match|do|suffices|show|by|in|at|let|forall|fun|exists|assume|from)\\b",
+      "match": "\\b(?<!\\.)(calc|have|this|match|do|suffices|show|by|in|at|let|forall|fun|exists|assume|from)(?!\\.)\\b",
       "name": "keyword.other.lean"
     },
     {"begin": "«", "end": "»", "contentName": "entity.name.lean"},


### PR DESCRIPTION
This PR fixes the following:
```lean
variables (A : Type*)
class MWE extends has_zero A
```
```lean
set_option class.instance_max_depth 5
```
[Reported here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/subject/VScode.20extension/near/133300183).

The change addressing the second example could be applied more generally, but I haven't bothered to do this since I don't yet see any other _valid_ lean syntax with incorrect highlighting.

Edit: another similar example fixed:
```lean
#check exists.intro
#check exists.elim
```