### PR TITLE
fix comment highlighting bug: -- disabling -/

### DIFF
--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -55,23 +55,27 @@
     { "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+))\\b", "name": "constant.numeric.lean" }
   ],
   "repository": {
-    "blockComment": {
-      "begin": "/-[^-]", "end": "-/", "name": "comment.block.lean",
-      "patterns": [{"include": "#blockComment"}]
-    },
-    "docComment": {
-      "begin": "/--", "end": "-/", "name": "comment.block.documentation.lean"
-    },
     "dashComment": {
       "begin": "(--)", "end": "$",
       "beginCaptures": {"0": {"name": "punctuation.definition.comment.lean"}},
       "name": "comment.line.double-dash.lean"
     },
+    "docComment": {
+      "begin": "/--", "end": "-/", "name": "comment.block.documentation.lean"
+    },
+    "modDocComment": {
+      "begin": "/-!", "end": "-/", "name": "comment.block.documentation.lean"
+    },
+    "blockComment": {
+      "begin": "/-", "end": "-/", "name": "comment.block.lean",
+      "patterns": [{"include": "#blockComment"}]
+    },
     "comments": {
       "patterns": [
-        {"include": "#blockComment"},
+        {"include": "#dashComment"},
         {"include": "#docComment"},
-        {"include": "#dashComment"}
+        {"include": "#modDocComment"},
+        {"include": "#blockComment"}
       ]
     },
     "definitionName": {

--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -57,21 +57,26 @@
   "repository": {
     "blockComment": {
       "begin": "/-[^-]", "end": "-/", "name": "comment.block.lean",
-      "patterns": [{"include": "#comments"}]
+      "patterns": [{"include": "#longComments"}]
     },
     "docComment": {
       "begin": "/--", "end": "-/", "name": "comment.block.documentation.lean",
-      "patterns": [{"include": "#comments"}]
+      "patterns": [{"include": "#longComments"}]
     },
     "dashComment": {
       "begin": "(--)", "end": "$",
       "beginCaptures": {"0": {"name": "punctuation.definition.comment.lean"}},
       "name": "comment.line.double-dash.lean"
     },
-    "comments": {
+    "longComments": {
       "patterns": [
         {"include": "#blockComment"},
-        {"include": "#docComment"},
+        {"include": "#docComment"}
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {"include": "#longComments"},
         {"include": "#dashComment"}
       ]
     },

--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -57,26 +57,20 @@
   "repository": {
     "blockComment": {
       "begin": "/-[^-]", "end": "-/", "name": "comment.block.lean",
-      "patterns": [{"include": "#longComments"}]
+      "patterns": [{"include": "#blockComment"}]
     },
     "docComment": {
-      "begin": "/--", "end": "-/", "name": "comment.block.documentation.lean",
-      "patterns": [{"include": "#longComments"}]
+      "begin": "/--", "end": "-/", "name": "comment.block.documentation.lean"
     },
     "dashComment": {
       "begin": "(--)", "end": "$",
       "beginCaptures": {"0": {"name": "punctuation.definition.comment.lean"}},
       "name": "comment.line.double-dash.lean"
     },
-    "longComments": {
-      "patterns": [
-        {"include": "#blockComment"},
-        {"include": "#docComment"}
-      ]
-    },
     "comments": {
       "patterns": [
-        {"include": "#longComments"},
+        {"include": "#blockComment"},
+        {"include": "#docComment"},
         {"include": "#dashComment"}
       ]
     },


### PR DESCRIPTION
This PR is aimed at fixing examples like this:
```lean
/- -- -/
#print true
```
The extension currently highlights everything as a comment, since the `--` marker prevents the `-/` from being detected.

**edit:** the first commit wasn't quite right; [the scanner](https://github.com/leanprover/lean/blob/ceacfa7445953cbc8860ddabc55407430a9ca5c3/src/frontends/lean/scanner.cpp#L341) only pays attention to the nesting of block comments and not doc comments. The second commit thus also fixes the highlighting of:
```lean
/---/
example : true := trivial
```
```lean
/--/--/
example : true := trivial
```
```lean
/--/- /--/
example : true := trivial
```
etc.

**edit 2:** the third commit now treats the "mod doc block" `/-!` syntax. I also reordered the include rules in the repository to better mirror the structure of the scanner, which slightly simplified things.