### PR TITLE
add command to toggle infoview updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,12 @@
 				"description": "Copy the current contents of the info view into a new comment on the next line"
 			},
 			{
+				"command": "lean.infoView.toggleUpdating",
+				"category": "Lean",
+				"title": "Info View: toggle updating",
+				"description": "Pause / Continue the live updating in the info view"
+			},
+			{
 				"command": "lean.roiMode.select",
 				"category": "Lean",
 				"title": "Select region-of-interest",

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -93,6 +93,13 @@ export class InfoProvider implements Disposable {
             }),
             commands.registerTextEditorCommand('lean.infoView.copyToComment',
                 (editor) => this.copyToComment(editor)),
+            commands.registerTextEditorCommand('lean.infoView.toggleUpdating', (editor) => {
+                if (this.stopped) {
+                    this.setMode(this.displayMode);
+                } else {
+                    this.stopUpdating();
+                }
+            })
         );
     }
 


### PR DESCRIPTION
This PR makes it possible to assign a keyboard command to toggle the live updating of the infoview, particularly because the infoview frequently goes blank for long periods of time while editing a slow-compiling file (see e.g. issue [#92](https://github.com/leanprover/vscode-lean/issues/92)).