### PR TITLE
Custom translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
 					"type" : "object",
 					"items" : {
 						"type" : "string",
-						"description": "unicode character to translate to"
+						"description": "Unicode character to translate to."
 					},
 					"default" : {},
-					"description": "Add additional input unicode translations. Example: `{\"foo\": \"☺\"}` will correct `\\foo` to `☺`. (reload necessary)"
+					"description": "Add additional input unicode translations. Example: `{\"foo\": \"☺\"}` will correct `\\foo` to `☺`."
 				},
 				"lean.input.languages": {
 					"type": "array",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,12 @@
 				"lean.input.markdown" : {
 					"type" : "boolean",
 					"default" : true,
-					"description": "Enable Lean input mode in markdown files."
+					"description": "Enable Lean input mode in markdown files. (reload necessary)"
+				},
+				"lean.input.customTranslations" : {
+					"type" : "object",
+					"default" : {},
+					"description": "Add additional input unicode translations. Example: `{\"foo\": \"☺\"}` will correct `\\foo` to `☺`. (reload necessary)"
 				},
 				"lean.input.leader": {
 					"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ function configExcludeOLean() {
 }
 
 let server: Server;
-type translations = {[key : string] : string}
+
 export function activate(context: ExtensionContext) {
     configExcludeOLean();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import * as loadJsonFile from 'load-json-file';
+import loadJsonFile from 'load-json-file';
 import { commands, ExtensionContext, languages, Uri, workspace } from 'vscode';
 import { batchExecuteFile } from './batch';
 import { LeanCompletionItemProvider } from './completion';
@@ -8,7 +8,7 @@ import { LeanDiagnosticsProvider } from './diagnostics';
 import { LeanHoles } from './holes';
 import { LeanHoverProvider } from './hover';
 import { InfoProvider } from './infoview';
-import { LeanInputAbbreviator, LeanInputExplanationHover } from './input';
+import { LeanInputAbbreviator, LeanInputExplanationHover, Translations } from './input';
 import { LeanpkgService } from './leanpkg';
 import { RoiManager } from './roi';
 import { LeanWorkspaceSymbolProvider } from './search';
@@ -27,7 +27,7 @@ function configExcludeOLean() {
 }
 
 let server: Server;
-
+type translations = {[key : string] : string}
 export function activate(context: ExtensionContext) {
     configExcludeOLean();
 
@@ -62,7 +62,9 @@ export function activate(context: ExtensionContext) {
 
     // Register support for unicode input.
     (async () => {
-        const translations : any = await loadJsonFile.default(context.asAbsolutePath('translations.json'));
+        const translations : translations = await loadJsonFile<translations>(context.asAbsolutePath('translations.json'));
+        const custom_translations : translations = workspace.getConfiguration("lean.input").get("customTranslations") || {};
+        Object.assign (translations, custom_translations);
         const modes = [LEAN_MODE];
         const input_markdown = workspace.getConfiguration('lean.input').get('markdown');
         if (input_markdown) {modes.push(MARKDOWN_MODE);}

--- a/src/input.ts
+++ b/src/input.ts
@@ -17,19 +17,31 @@ function inputModeLanguages(): string[] {
     return workspace.getConfiguration('lean.input').get('languages', ['lean']);
 }
 
+function inputModeCustomTranslations() : Translations {
+    return workspace.getConfiguration('lean.input').get("customTranslations", {});
+}
+
 /** Adds hover behaviour for getting translations of unicode characters. Eg: "Type ⊓ using \glb or \sqcap"  */
 export class LeanInputExplanationHover implements HoverProvider, Disposable {
     private leader = inputModeLeader();
+    private customTranslations = inputModeCustomTranslations();
     private subscriptions: Disposable[] = [];
 
     constructor(private translations: Translations) {
         this.subscriptions.push(
-            workspace.onDidChangeConfiguration(() => this.leader = inputModeLeader()));
+            workspace.onDidChangeConfiguration(() => {
+                this.leader = inputModeLeader();
+                this.customTranslations = inputModeCustomTranslations();
+            }));
     }
 
     getAbbrevations(symbol: string): string[] {
         const abbrevs: string[] = [];
+        for (const k in this.customTranslations) {
+            if (this.customTranslations[k] === symbol) { abbrevs.push(k); }
+        }
         for (const k in this.translations) {
+            if (this.customTranslations[k]) {continue;}
             if (this.translations[k] === symbol) { abbrevs.push(k); }
         }
         return abbrevs;
@@ -162,6 +174,8 @@ export class LeanInputAbbreviator {
     leader = inputModeLeader();
     enabled = inputModeEnabled();
     languages = inputModeLanguages();
+    customTranslations = inputModeCustomTranslations();
+    allTranslations : Translations;
 
     private handlers = new Map<TextEditor, TextEditorAbbrevHandler>();
 
@@ -169,6 +183,7 @@ export class LeanInputAbbreviator {
 
     constructor(private translations: Translations) {
         this.translations = Object.assign({}, translations);
+        this.allTranslations = {...this.translations, ...this.customTranslations};
 
         this.decorationType = window.createTextEditorDecorationType({
             textDecoration: 'underline',
@@ -201,6 +216,8 @@ export class LeanInputAbbreviator {
             this.leader = inputModeLeader();
             this.enabled = inputModeEnabled();
             this.languages = inputModeLanguages();
+            this.customTranslations = inputModeCustomTranslations();
+            this.allTranslations = {...this.translations, ...this.customTranslations}
         }));
     }
 
@@ -220,17 +237,17 @@ export class LeanInputAbbreviator {
     findReplacement(typedAbbrev: string): string | undefined {
         if (typedAbbrev === '') { return undefined; }
 
-        if (this.translations[typedAbbrev]) { return this.translations[typedAbbrev]; }
+        if (this.allTranslations[typedAbbrev]) { return this.allTranslations[typedAbbrev]; }
 
         let shortestExtension: string = null;
-        for (const abbrev in this.translations) {
+        for (const abbrev in this.allTranslations) {
             if (abbrev.startsWith(typedAbbrev) && (!shortestExtension || abbrev.length < shortestExtension.length)) {
                 shortestExtension = abbrev;
             }
         }
 
         if (shortestExtension) {
-            return this.translations[shortestExtension];
+            return this.allTranslations[shortestExtension];
         } else if (typedAbbrev) {
             const prefixReplacement = this.findReplacement(
                 typedAbbrev.slice(0, typedAbbrev.length - 1));

--- a/src/input.ts
+++ b/src/input.ts
@@ -17,8 +17,8 @@ function inputModeLanguages(): string[] {
     return workspace.getConfiguration('lean.input').get('languages', ['lean']);
 }
 
-function inputModeCustomTranslations() : Translations {
-    return workspace.getConfiguration('lean.input').get("customTranslations", {});
+function inputModeCustomTranslations(): Translations {
+    return workspace.getConfiguration('lean.input').get('customTranslations', {});
 }
 
 /** Adds hover behaviour for getting translations of unicode characters. Eg: "Type ⊓ using \glb or \sqcap"  */
@@ -175,7 +175,7 @@ export class LeanInputAbbreviator {
     enabled = inputModeEnabled();
     languages = inputModeLanguages();
     customTranslations = inputModeCustomTranslations();
-    allTranslations : Translations;
+    allTranslations: Translations;
 
     private handlers = new Map<TextEditor, TextEditorAbbrevHandler>();
 
@@ -217,7 +217,7 @@ export class LeanInputAbbreviator {
             this.enabled = inputModeEnabled();
             this.languages = inputModeLanguages();
             this.customTranslations = inputModeCustomTranslations();
-            this.allTranslations = {...this.translations, ...this.customTranslations}
+            this.allTranslations = {...this.translations, ...this.customTranslations};
         }));
     }
 


### PR DESCRIPTION
Add a new configuration setting `customTranslations`. It is merged with `translations.json`, `customTranslations` overwrites already defined keys in `translations.json`.
The use case is that sometimes the author will have a particular symbol that they want to write a lot. Eg: I have been writing `\McC` a lot and would rather override `\C` to speed up typing a bit.
### Example:
``` json
        "lean.input.customTranslations": {
            "foo": "☺",
            "bar" : "☮",
            "C": "𝒞"
        }
```

If `customTranslations` is defined in both User Settings and Workspace Settings, vscode merges the objects with Workspace taking precedence. So if I add `"bar": "⋇"` to Workspace `customTranslations`. Then `\bar` will correct to that in the workspace but the user can still use `\foo`.