### PR TITLE
tactic state filter [RFC]

### DIFF
--- a/media/infoview.css
+++ b/media/infoview.css
@@ -39,6 +39,16 @@ a {
   text-decoration: none;
 }
 
+div#filter {
+  display: block;
+  position: absolute;
+  top : 0px;
+  right: 90px;
+  width: auto;
+  padding: 3px 0px 1px 0px;
+  z-index: 2;
+}
+
 div#run-state {
   display: block;
   position: fixed;

--- a/package.json
+++ b/package.json
@@ -94,6 +94,20 @@
 					"type": "string",
 					"default": "",
 					"description": "Add an additional CSS snippet to the info view."
+				},
+				"lean.infoViewTacticStateFilters": {
+					"type": "array",
+					"default": ["^(?!_)."],
+					"description": "An array of regular expression strings that can be used to filter the tactic state in the info view. When a filter is enabled, only lines matching the regex are displayed. Set to an empty array '[]' to hide the filter select dropdown.",
+					"items": {
+						"type": "string",
+						"description": "a properly-escaped regex string, e.g. '^(?!_).' will match all lines in the tactic state that do not begin with an underscore."
+					}
+				},
+				"lean.infoViewFilterIndex": {
+					"type": "number",
+					"default": -1,
+					"description": "Index of the filter applied to the tactic state (in the array infoViewTacticStateFilters). An index of -1 means no filter is applied."
 				}
 			}
 		},


### PR DESCRIPTION
This PR addresses issue #100. It adds a dropdown menu to the info view which allows filtering of the tactic state with regex strings (the list of options is configurable via editing the new settings `lean.infoViewTacticStateFilters` and `lean.infoViewFilterIndex`).