### PR TITLE
fix hover functionality in info view

### DIFF
--- a/media/infoview-ctrl.js
+++ b/media/infoview-ctrl.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 'use strict';
 
 (function () {
@@ -19,7 +17,7 @@ function debug(s) {
 function setMarker(parent, atTop, t) {
   const old_m = document.getElementById(ID_MARKER);
   if (old_m) old_m.remove();
-  
+
   const m = document.createElement("span");
   m.setAttribute("id", ID_MARKER);
   m.innerText = t;
@@ -68,7 +66,7 @@ function getPosition(elem) {
   return {
     line: Number.parseInt(elem.getAttribute("data-line")),
     column: Number.parseInt(elem.getAttribute("data-column"))
-  }
+  };
 }
 
 function isEqual(p1, p2) {
@@ -76,7 +74,7 @@ function isEqual(p1, p2) {
 }
 
 function isBefore(p1, p2) {
-  return p1.line < p2.line || (p1.line == p2.line && p1.column < p2.column); 
+  return p1.line < p2.line || (p1.line == p2.line && p1.column < p2.column);
 }
 
 function onPosition(rpos) {
@@ -148,17 +146,16 @@ function setupHover() {
     m.addEventListener("mouseenter", event => {
       const data = [document.body.getAttribute('data-uri'),
         Number.parseInt(m.getAttribute('data-line')),
-        Number.parseInt(m.getAttribute('data-column'))];
-			window.parent.postMessage({
-				command: "did-click-link",
-				data: `command:_lean.hoverPosition?${encodeURIComponent(JSON.stringify(data))}`
-			}, "file://");
+        Number.parseInt(m.getAttribute('data-column')),
+        Number.parseInt(m.getAttribute('data-end-line')),
+        Number.parseInt(m.getAttribute('data-end-column'))];
+          vscode.postMessage({
+            command: "hoverPosition",
+            data: data
+          });
     });
     m.addEventListener("mouseleave", event => {
-			window.parent.postMessage({
-				command: "did-click-link",
-				data: `command:_lean.stopHover`
-			}, "file://");
+      vscode.postMessage({ command: "stopHover" });
     });
   }
 }
@@ -178,4 +175,6 @@ if (document.readyState === 'loading') {
 	onLoad();
 }
 
-})()
+const vscode = acquireVsCodeApi();
+
+})();

--- a/media/infoview.css
+++ b/media/infoview.css
@@ -136,7 +136,6 @@ div#run-state {
   background-color: #222;
 }
 
-
 .vscode-high-contrast h1 {
   border-bottom-color: white;
 }

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -69,8 +69,6 @@ export class InfoProvider implements Disposable {
                 this.rerender();
             }),
             commands.registerCommand('_lean.revealPosition', this.revealEditorPosition),
-            commands.registerCommand('_lean.hoverPosition', (u, l, c) => { this.hoverEditorPosition(u, l, c); }),
-            commands.registerCommand('_lean.stopHover', () => { this.stopHover(); }),
             commands.registerCommand('_lean.infoView.pause', () => {
                 this.stopUpdating();
             }),
@@ -138,6 +136,17 @@ export class InfoProvider implements Disposable {
                 });
             this.webviewPanel.webview.html = this.render();
             this.webviewPanel.onDidDispose(() => this.webviewPanel = null);
+            this.webviewPanel.webview.onDidReceiveMessage((message) => {
+                switch (message.command) {
+                    case 'hoverPosition':
+                        this.hoverEditorPosition(message.data[0], message.data[1], message.data[2],
+                            message.data[3], message.data[4]);
+                        return;
+                    case 'stopHover':
+                        this.stopHover();
+                        return;
+                }
+            }, undefined, this.subscriptions);
         }
     }
 
@@ -179,18 +188,19 @@ export class InfoProvider implements Disposable {
         for (const editor of window.visibleTextEditors) {
             if (editor.document.uri.toString() === uri.toString()) {
                 const pos = new Position(line - 1, column);
-                window.showTextDocument(editor.document);
                 editor.revealRange(new Range(pos, pos), TextEditorRevealType.InCenterIfOutsideViewport);
                 editor.selection = new Selection(pos, pos);
             }
         }
     }
 
-    private hoverEditorPosition(uri: string, line: number, column: number) {
+    private hoverEditorPosition(uri: string, line: number, column: number,
+                                endLine: number, endColumn: number) {
         for (const editor of window.visibleTextEditors) {
             if (editor.document.uri.toString() === uri) {
                 const pos = new Position(line - 1, column);
-                const range = new Range(pos, pos.translate(0, 1));
+                const endPos = new Position(endLine - 1, endColumn);
+                const range = new Range(pos, endPos);
                 editor.setDecorations(this.hoverDecorationType, [range]);
             }
         }
@@ -334,9 +344,9 @@ export class InfoProvider implements Disposable {
         const header = `<!DOCTYPE html>
             <html>
             <head>
-              <meta http-equiv="Content-type" content="text/html;charset=utf-8">
-              <style>${escapeHtml(this.stylesheet)}</style>
-              <script charset="utf-8" src="${this.getMediaPath('infoview-ctrl.js')}"></script>
+                <meta http-equiv="Content-type" content="text/html;charset=utf-8">
+                <style>${escapeHtml(this.stylesheet)}</style>
+                <script charset="utf-8" src="${this.getMediaPath('infoview-ctrl.js')}"></script>
             </head>`;
         if (!this.curFileName) {
             return header + '<body>No Lean file active</body>';
@@ -347,15 +357,15 @@ export class InfoProvider implements Disposable {
                 data-line="${(this.curPosition.line + 1).toString()}"
                 data-column="${this.curPosition.character.toString()}"
                 ${this.displayMode === DisplayMode.AllMessage ? "data-messages=''" : ''}>
-              <div id="debug"></div>
-              <div id="run-state">
-                <span id="state-continue">Stopped <a href="command:_lean.infoView.continue?{}">
-                  <img title="Continue Updating" src="${this.getMediaPath('continue.svg')}"></a></span>
-                <span id="state-pause">Updating <a href="command:_lean.infoView.pause?{}">
-                  <img title="Stop Updating" src="${this.getMediaPath('pause.svg')}"></span></a>
-              </div>
-              ${this.renderGoal()}
-              <div id="messages">${this.renderMessages()}</div>
+                <div id="debug"></div>
+                <div id="run-state">
+                    <span id="state-continue">Stopped <a href="command:_lean.infoView.continue?{}">
+                        <img title="Continue Updating" src="${this.getMediaPath('continue.svg')}"></a></span>
+                    <span id="state-pause">Updating <a href="command:_lean.infoView.pause?{}">
+                        <img title="Stop Updating" src="${this.getMediaPath('pause.svg')}"></span></a>
+                </div>
+                ${this.renderGoal()}
+                <div id="messages">${this.renderMessages()}</div>
             </body></html>`;
     }
 
@@ -378,13 +388,16 @@ export class InfoProvider implements Disposable {
         if (!this.curFileName || !this.curMessages) { return ``; }
         return this.curMessages.map((m) => {
             const f = escapeHtml(m.file_name); const b = escapeHtml(basename(m.file_name));
-            const l = m.pos_line.toString(); const c = m.pos_col.toString();
+            const l = m.pos_line; const c = m.pos_col;
+            const el = m.end_pos_line || l;
+            const ec = m.end_pos_col || c;
             const cmd = encodeURI('command:_lean.revealPosition?' +
                 JSON.stringify([Uri.file(m.file_name), m.pos_line, m.pos_col]));
             const shouldColorize = m.severity === 'error';
             const colorized = shouldColorize ? this.colorizeMessage(m.text) :
                 escapeHtml(m.text);
-            return `<div class="message ${m.severity}" data-line="${l}" data-column="${c}">
+            return `<div class="message ${m.severity}" data-line="${l}" data-column="${c}"
+                data-end-line="${el}" data-end-column="${ec}">
                 <h1 title="${f}:${l}:${c}"><a href="${cmd}">
                     ${b}:${l}:${c}: ${m.severity} ${escapeHtml(m.caption)}
                 </a></h1>


### PR DESCRIPTION
Depends on #101.

The code for hovering in the info view was written for the old `previewHTML()` command. I've moved the code from infoview-ctrl.js to infoview.ts so that it can make use of the new `acquireVsCodeApi()` object for passing messages to the extension.

This PR also contains a fix so that clicking on the message titles in the info view now scrolls you to the correct place in the open editor (rather than the current behavior of opening a new editor window).