### PR TITLE
auto-open info view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We currently support a variety of features.
 * Auto-completion based on context and type via the Lean server
 * Error messages / diagnostics
 * Customizable Unicode input support (e.g. type `\la`+<kbd>tab</kbd> to input `λ`)
-* Info view window to show goal, tactic state, and error messages (ctrl+shift+enter for local goal view or ctrl+shift+alt+enter for all messages)
+* Info view window to show goal, tactic state, and error messages (<kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>enter</kbd> for local goal view or <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>alt</kbd>+<kbd>enter</kbd> for all messages)
 * Batch file execution
 * Search for declarations in open files (<kbd>ctrl</kbd>+<kbd>p</kbd> #)
 * Region of interest checking (i.e. control how much of the project is checked automatically by Lean)
@@ -40,6 +40,7 @@ This extension contributes the following settings (for a complete list, open the
   - `project`: check the entire project's files
 * `lean.input.leader`: character to type to trigger Unicode input mode (`\` by default)
 * `lean.input.languages`: allows the Unicode input functionality to be used in other languages
+* `lean.infoViewAutoOpen`: controls whether the info view is automatically displayed when the Lean extension is activated (`true` by default).
 * `lean.infoViewTacticStateFilters`: An array of objects containing regular expression strings that can be used to filter (positively or negatively) the tactic state in the info view. Set to an empty array `[]` to hide the filter select dropdown. Each object must contain the following keys:
   - `regex` is a properly-escaped regex string,
   - `match` is a boolean, where `true` (`false`) means blocks in the tactic state matching `regex` will be included (excluded) in the info view,
@@ -59,7 +60,7 @@ It also contributes the following commands, which can be bound to keys if desire
 
 ### Other potentially helpful settings
 
-* Fonts with good Unicode support: `"editor.fontFamily": "Source Code Pro Medium, DejaVu Sans Mono"`. Note that for this configuration to work properly, both fonts must be specified in this order (so that characters that are not available in [Source Code Pro](https://github.com/adobe-fonts/source-code-pro) are rendered using [DejaVu Sans Mono](https://dejavu-fonts.github.io/).
+* Fonts with good Unicode support: `"editor.fontFamily": "Source Code Pro Medium, DejaVu Sans Mono"`. Note that for this configuration to work properly, both fonts must be specified in this order (so that characters that are not available in [Source Code Pro](https://github.com/adobe-fonts/source-code-pro) are rendered using [DejaVu Sans Mono](https://dejavu-fonts.github.io/)).
 * By default, VS Code will complete `then` to `has_bind.and_then` when you press enter.  To disable this behavior, set `"editor.acceptSuggestionOnEnter": false`
 * If you like colored brackets, try out [Bracket Pair Colorizer 2](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2).
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
 					"default": false,
 					"description": "Info view: show all errors on the current line, instead of just the ones on the right of the cursor."
 				},
+				"lean.infoViewAutoOpen": {
+					"type": "boolean",
+					"default": true,
+					"description": "Info view: open info view when Lean extension is activated."
+				},
 				"lean.infoViewStyle": {
 					"type": "string",
 					"default": "",

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -37,6 +37,7 @@ export class InfoProvider implements Disposable {
 
     private displayMode: DisplayMode = DisplayMode.AllMessage;
 
+    private started: boolean = false;
     private stopped: boolean = false;
     private curFileName: string = null;
     private curPosition: Position = null;
@@ -62,6 +63,9 @@ export class InfoProvider implements Disposable {
                     const changed = await this.updateGoal();
                     if (changed) { this.rerender(); }
                 }
+            }),
+            this.server.restarted.on(() => {
+                this.autoOpen();
             }),
             window.onDidChangeTextEditorSelection(() => this.updatePosition(false)),
             workspace.onDidChangeConfiguration((e) => {
@@ -99,11 +103,6 @@ export class InfoProvider implements Disposable {
                 }
             }),
         );
-
-        if (workspace.getConfiguration('lean').get('infoViewAutoOpen')) {
-            this.openPreview(window.activeTextEditor);
-            this.updatePosition(false);
-        }
     }
 
     dispose() {
@@ -123,6 +122,14 @@ export class InfoProvider implements Disposable {
             }
             ` +
             workspace.getConfiguration('lean').get('infoViewStyle');
+    }
+
+    private autoOpen() {
+        if (!this.started && workspace.getConfiguration('lean').get('infoViewAutoOpen')) {
+            this.started = true;
+            this.openPreview(window.activeTextEditor);
+            this.updatePosition(false);
+        }
     }
 
     private openPreview(editor: TextEditor) {

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -67,6 +67,7 @@ export class InfoProvider implements Disposable {
             this.server.restarted.on(() => {
                 this.autoOpen();
             }),
+            window.onDidChangeActiveTextEditor(() => this.updatePosition(false)),
             window.onDidChangeTextEditorSelection(() => this.updatePosition(false)),
             workspace.onDidChangeConfiguration((e) => {
                 this.updateStylesheet();

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -103,6 +103,9 @@ export class InfoProvider implements Disposable {
                 }
             }),
         );
+        if (this.server.alive()) {
+            this.autoOpen();
+        }
     }
 
     dispose() {

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -99,6 +99,11 @@ export class InfoProvider implements Disposable {
                 }
             }),
         );
+
+        if (workspace.getConfiguration('lean').get('infoViewAutoOpen')) {
+            this.openPreview(window.activeTextEditor);
+            this.updatePosition(false);
+        }
     }
 
     dispose() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -194,8 +194,4 @@ export class Server extends leanclient.Server {
             this.installElan();
         }
     }
-
-    dispose() {
-        super.dispose();
-    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -194,4 +194,8 @@ export class Server extends leanclient.Server {
             this.installElan();
         }
     }
+
+    dispose() {
+        super.dispose();
+    }
 }

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -4,6 +4,8 @@ import { Server } from './server';
 
 export class LeanStatusBarItem implements Disposable {
     statusBarItem: StatusBarItem;
+    private shown: boolean = false;
+
     private subscriptions: Disposable[] = [];
 
     constructor(private server: Server, private roiManager: RoiManager) {
@@ -18,8 +20,9 @@ export class LeanStatusBarItem implements Disposable {
             this.statusBarItem.command = 'lean.roiMode.select';
         }
 
-        this.update();
-        this.statusBarItem.show();
+        if (this.server.alive()) {
+            this.update();
+        }
     }
 
     update() {
@@ -43,6 +46,10 @@ export class LeanStatusBarItem implements Disposable {
             case RoiMode.ProjectFiles: text += ' (checking project files)'; break;
         }
 
+        if (!this.shown) {
+            this.statusBarItem.show();
+            this.shown = true;
+        }
         this.statusBarItem.text = text;
     }
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -31,7 +31,6 @@ export class LeanSyncService implements Disposable {
         if (!this.didAutoStartServer && !this.server.alive()) {
             this.didAutoStartServer = true;
             this.server.connect();
-            return;
         }
         this.server.sync(doc.fileName, doc.getText());
     }


### PR DESCRIPTION
Addresses #104

One thought: this could potentially be annoying for anyone who is just using this extension for unicode input for other languages. However, it seems to me we're already automatically loading a bunch of other Lean-only stuff when the extension is activated, so that should be addressed at a higher level, if at all.  In any case the auto-open can be turned off with the config option `lean.infoViewAutoOpen` if desired.