### PR TITLE
infoview default column Two instead of Three

### DIFF
--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -140,7 +140,7 @@ export class InfoProvider implements Disposable {
     }
 
     private openPreview(editor: TextEditor) {
-        let column = editor ? editor.viewColumn + 1 : ViewColumn.Three;
+        let column = editor ? editor.viewColumn + 1 : ViewColumn.Two;
         if (column === 4) { column = ViewColumn.Three; }
         if (this.webviewPanel) {
             this.webviewPanel.reveal(column, true);


### PR DESCRIPTION
If I have the infoview window selected in vscode lean and then reopen vscode, the extension auto-opens a webview in column Three, leaving a blank column in the middle. This happens because the editor object that's passed to openPreview is undefined if the previously selected window was the infoview and the default column is set to Three here.

This PR sets that default column to Two.