### PR TITLE
fix attempts to iterate over "undefined"

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -44,16 +44,18 @@ export class LeanCompletionItemProvider implements CompletionItemProvider {
         if (!isInputCompletion(document, position)) {
             const message = await this.server.complete(document.fileName, position.line + 1, position.character);
             const completions: CompletionItem[] = [];
-            for (const completion of message.completions) {
-                const item = new CompletionItem(completion.text, CompletionItemKind.Function);
-                item.range = new Range(position.translate(0, -message.prefix.length), position);
-                if (completion.tactic_params) {
-                    item.detail = completion.tactic_params.join(' ');
-                } else {
-                    item.detail = completion.type;
+            if (message.completions) {
+                for (const completion of message.completions) {
+                    const item = new CompletionItem(completion.text, CompletionItemKind.Function);
+                    item.range = new Range(position.translate(0, -message.prefix.length), position);
+                    if (completion.tactic_params) {
+                        item.detail = completion.tactic_params.join(' ');
+                    } else {
+                        item.detail = completion.type;
+                    }
+                    item.documentation = new MarkdownString(completion.doc);
+                    completions.push(item);
                 }
-                item.documentation = new MarkdownString(completion.doc);
-                completions.push(item);
             }
             for (const kw of keywords) {
                 completions.push(new CompletionItem(kw, CompletionItemKind.Keyword));

--- a/src/holes.ts
+++ b/src/holes.ts
@@ -11,7 +11,7 @@ function mkRange(r: Ran): Range {
 }
 
 export class LeanHoles implements Disposable, CodeActionProvider {
-    private holes: HoleCommands[];
+    private holes: HoleCommands[] = [];
     private collection: DiagnosticCollection;
     private subscriptions: Disposable[] = [];
 


### PR DESCRIPTION
This PR fixes two error messages that I noticed which arise from attempts to iterate over undefined variables:

In `completion.ts`, sometimes `message.completions` is undefined; I've added a check against this.

In `holes.ts`, when the `LeanHoles` object is constructed, `this.holes` is undefined, leading to an error in `provideCodeActions`. I've initialized it to `[]`.