### PR TITLE
feature: display type in status bar item

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We currently support a variety of features.
 * Fill in `{! !}` holes using <kbd>ctrl</kbd>+<kbd>.</kbd>
 * Tasks for leanpkg (<kbd>ctrl</kbd>+<kbd>p</kbd> task configure)
 * Tactic state filtering with regex
+* Type of the term under the cursor can be displayed in the status bar
 
 ## Requirements
 
@@ -47,6 +48,7 @@ This extension contributes the following settings (for a complete list, open the
   - `flags` are additional flags passed to the [JavaScript RegExp constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
   - The `name` key is optional and may contain a string that is displayed in the dropdown instead of the full regex details.
 * `lean.infoViewFilterIndex`: index of the filter applied to the tactic state (in the array `lean.infoViewTacticStateFilters`). An index of -1 means no filter is applied.
+* `lean.typeInStatusBar`: controls whether the type of the term under the cursor is displayed as a status bar item (`true` by default).
 
 It also contributes the following commands, which can be bound to keys if desired:
 

--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
 					"type": "number",
 					"default": -1,
 					"description": "Index of the filter applied to the tactic state (in the array infoViewTacticStateFilters). An index of -1 means no filter is applied."
+				},
+				"lean.typeInStatusBar": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show the type of term under the cursor in the status bar."
 				}
 			}
 		},

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { Message, InfoResponse } from 'lean-client-js-node';
+import { InfoResponse, Message } from 'lean-client-js-node';
 import { basename, join } from 'path';
 import {
     commands, Disposable, DocumentSelector,
@@ -381,7 +381,7 @@ export class InfoProvider implements Disposable {
         if (info.record) {
             const name = info.record['full-id'] || info.record.text;
             if (name && !info.record.tactic_params) {
-                text += name + ' : ' + info.record.type;
+                text = name + ' : ' + info.record.type;
             }
         }
         if (!this.statusShown) {

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -377,13 +377,11 @@ export class InfoProvider implements Disposable {
     }
 
     private updateTypeStatus(info: InfoResponse) {
-        let text = 'Type: ';
+        let text = '';
         if (info.record) {
             const name = info.record['full-id'] || info.record.text;
-            if (name) {
-                if (!info.record.tactic_params) {
-                    text += name + ' : ' + info.record.type;
-                }
+            if (name && !info.record.tactic_params) {
+                text += name + ' : ' + info.record.type;
             }
         }
         if (!this.statusShown) {

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -272,6 +272,8 @@ export class InfoProvider implements Disposable {
         }
 
         const chMsg = this.updateMessages();
+        /* updateTypeStatus is only called from the cases of the following switch-block, so pausing
+           live-updates to the infoview (via this.stopped) also pauses the type status bar item */
         switch (this.displayMode) {
         case DisplayMode.OnlyState:
             const chGoal = await this.updateGoal();


### PR DESCRIPTION
This adds a status bar item (on by default, configurable with `lean.typeInStatusBar`) which displays the type information for the term underneath the cursor.

This addresses [a request](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/VScode.20extension/near/161738201) of @jcommelin. 

I first tried implementing this new status bar item in a new class, but I found that the info view provider's frequent server requests were interrupting those made by the new class. So, I've placed this feature in `infoview.ts` so that the status bar item can reuse the info from the requests that are already being made to the lean server.