### PR TITLE
remove hover decorations on rerender

### DIFF
--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -208,6 +208,7 @@ export class InfoProvider implements Disposable {
     private rerender() {
         if (this.webviewPanel) {
             this.webviewPanel.webview.html = this.render();
+            this.stopHover();
         }
     }
     private async postMessage(msg: any): Promise<boolean> {


### PR DESCRIPTION
This fixes [an issue](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/dreaded.20red.20blocks.20of.20death.20are.20back/near/163319685) reported by @kbuzzard on Zulip: the red blocks which appear when hovering over errors in the info view can get stuck if the code is edited before the mouse is removed.