### PR TITLE
Better completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This extension contributes the following settings (for a complete list, open the
   - The `name` key is optional and may contain a string that is displayed in the dropdown instead of the full regex details.
 * `lean.infoViewFilterIndex`: index of the filter applied to the tactic state (in the array `lean.infoViewTacticStateFilters`). An index of -1 means no filter is applied.
 * `lean.typeInStatusBar`: controls whether the type of the term under the cursor is displayed as a status bar item (`true` by default).
+* `lean.typesInCompletionList`: controls whether the types of all items in the list of completions are displayed. By default, only the type of the highlighted item is shown.
 
 It also contributes the following commands, which can be bound to keys if desired:
 

--- a/package.json
+++ b/package.json
@@ -161,6 +161,11 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Show the type of term under the cursor in the status bar."
+				},
+				"lean.typesInCompletionList": {
+					"type": "boolean",
+					"default": false,
+					"description": "Display types of all items in the list of completions. By default, only the type of the highlighted item is shown."
 				}
 			}
 		},

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -48,10 +48,13 @@ export class LeanCompletionItemProvider implements CompletionItemProvider {
                 for (const completion of message.completions) {
                     const item = new CompletionItem(completion.text, CompletionItemKind.Function);
                     item.range = new Range(position.translate(0, -message.prefix.length), position);
+                    item.insertText = completion.text;
                     if (completion.tactic_params) {
                         item.detail = completion.tactic_params.join(' ');
+                        item.label = item.label + ' ' + item.detail;
                     } else {
-                        item.detail = completion.type;
+                        item.detail = completion.type.replace(/\?([^\s]+)/g, '$1');
+                        item.label = item.label + ' : ' + item.detail;
                     }
                     item.documentation = new MarkdownString(completion.doc);
                     completions.push(item);

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,5 +1,5 @@
 import { CompletionItem, CompletionItemKind, CompletionItemProvider,
-    MarkdownString, Position, Range, TextDocument } from 'vscode';
+    MarkdownString, Position, Range, TextDocument, workspace } from 'vscode';
 import { Server } from './server';
 import { isInputCompletion } from './util';
 
@@ -48,13 +48,14 @@ export class LeanCompletionItemProvider implements CompletionItemProvider {
                 for (const completion of message.completions) {
                     const item = new CompletionItem(completion.text, CompletionItemKind.Function);
                     item.range = new Range(position.translate(0, -message.prefix.length), position);
-                    item.insertText = completion.text;
                     if (completion.tactic_params) {
                         item.detail = completion.tactic_params.join(' ');
-                        item.label = item.label + ' ' + item.detail;
                     } else {
-                        item.detail = completion.type.replace(/\?([^\s]+)/g, '$1');
-                        item.label = item.label + ' : ' + item.detail;
+                        item.detail = completion.type;
+                    }
+                    if (workspace.getConfiguration('lean').get('typesInCompletionList')) {
+                        item.insertText = completion.text;
+                        item.label = item.label + (completion.tactic_params ? ' ' + item.detail : ' : ' + item.detail);
                     }
                     item.documentation = new MarkdownString(completion.doc);
                     completions.push(item);


### PR DESCRIPTION
Adds new config option `lean.typesInCompletionList`, which controls whether the types of all items in the list of completions are displayed. Currently, only the type of the highlighted item is shown and this will continue to be the default.

Addresses #120, as suggested by @semorrison.