### PR TITLE
put type in status bar to the left of all default items

### DIFF
--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -53,7 +53,7 @@ export class InfoProvider implements Disposable {
 
     constructor(private server: Server, private leanDocs: DocumentSelector, private context: ExtensionContext) {
 
-        this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+        this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 1000);
 
         this.hoverDecorationType = window.createTextEditorDecorationType({
             backgroundColor: 'red', // make configurable?


### PR DESCRIPTION
VS Code 1.36.0 changed the priority of the default items in the status bar, (see https://github.com/microsoft/vscode/issues/38620); this PR increases the priority of the status bar item containing the type information so that it is back in its previous position to the left of the default items.