### PR TITLE
add input translation from \f<> to ‹›

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -77,6 +77,7 @@ class TextEditorAbbrevHandler {
             [this.leader + '[[]]']: '⟦⟧',
             [this.leader + '<>']: '⟨⟩',
             [this.leader + '([])'] : '⟮⟯',
+            [this.leader + 'f<>']: '‹›',
         };
         if (range) {
             const replacement = hackyReplacements[this.editor.document.getText(range)];


### PR DESCRIPTION
I haven't tried building this, but edited the translations.json locally,
ran with vscode and then applied the diff,
this has only been lightly tested within vscode itself as well, but seemed to work.

Anyhow it would be nice if we could save a few keystrokes inputting \f< \f>, by combining them into \f<>.
