### PR TITLE
Support paths relative to the extension path in lean.executableP…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We currently support a variety of features.
 * Search for declarations in open files (<kbd>ctrl</kbd>+<kbd>p</kbd> #)
 * Region of interest checking (i.e. control how much of the project is checked automatically by Lean)
 * Fill in `{! !}` holes using <kbd>ctrl</kbd>+<kbd>.</kbd>
-* Tasks for leanpkg (<kbd>ctrl</kbd>+<kbd>p</kbd> task configure)
+* Tasks for leanpkg (<kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> and select "Tasks: Configure Task")
 * Tactic state filtering with regex
 * Type of the term under the cursor can be displayed in the status bar
 
@@ -31,7 +31,8 @@ On Windows, if you installed Lean using MSYS2, you need to add both `C:\msys64\m
 
 This extension contributes the following settings (for a complete list, open the VS Code Settings and scroll to "Lean configuration"):
 
-* `lean.executablePath`: controls which Lean executable is used when starting the server
+* `lean.executablePath`: controls which Lean executable is used when starting the server. If you are bundling Lean and `vscode-lean` with [Portable mode VS Code](https://code.visualstudio.com/docs/editor/portable), you might find it useful to specify a relative path to Lean. This can be done by starting this setting string with `%extensionPath%`; the extension will replace this with the absolute path of the extension folder. For example, with the default directory setup in Portable mode, `%extensionPath%/../../../lean` will point to `lean` in the same folder as the VS Code executable / application.
+* `lean.leanpkgPath`: controls which leanpkg executable is used for `leanpkg` task integration. The `%extensionPath%` token can be used here as well.
 * `lean.timeLimit`: controls the `-T` flag passed to the Lean executable
 * `lean.memoryLimit`: controls the `-M` flag passed to the Lean executable
 * `lean.roiModeDefault`: controls the default region of interest, the options are:

--- a/src/leanpkg.ts
+++ b/src/leanpkg.ts
@@ -61,7 +61,7 @@ export class LeanpkgService implements TaskProvider, Disposable {
 
         const leanPath = config.get<string>('executablePath').replace('%extensionPath%', extensionPath + '/');
         if (leanPath) {
-            const leanpkg2 = path.join(path.dirname(leanPath), 'lean');
+            const leanpkg2 = path.join(path.dirname(leanPath), 'leanpkg');
             if (fs.existsSync(leanpkg2)) { return leanpkg2; }
         }
 

--- a/src/leanpkg.ts
+++ b/src/leanpkg.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { commands, Disposable, ProcessExecution, Task, TaskGroup, TaskProvider, Uri,
-    window, workspace } from 'vscode';
+import { commands, Disposable, extensions, ProcessExecution, Task, TaskGroup,
+    TaskProvider, Uri, window, workspace } from 'vscode';
 import { Server } from './server';
 
 export class LeanpkgService implements TaskProvider, Disposable {
@@ -55,10 +55,11 @@ export class LeanpkgService implements TaskProvider, Disposable {
     leanpkgExecutable(): string {
         const config = workspace.getConfiguration('lean');
 
-        const leanpkg = config.get<string>('leanpkgPath');
+        const {extensionPath} = extensions.getExtension('jroesch.lean');
+        const leanpkg = config.get<string>('leanpkgPath').replace('%extensionPath%', extensionPath + '/');
         if (leanpkg) { return leanpkg; }
 
-        const leanPath = config.get<string>('executablePath');
+        const leanPath = config.get<string>('executablePath').replace('%extensionPath%', extensionPath + '/');
         if (leanPath) {
             const leanpkg2 = path.join(path.dirname(leanPath), 'lean');
             if (fs.existsSync(leanpkg2)) { return leanpkg2; }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { Event, Message, ProcessTransport, Task } from 'lean-client-js-node';
 import { homedir } from 'os';
 import { resolve } from 'path';
 import * as username from 'username';
-import { OutputChannel, TerminalOptions, window, workspace } from 'vscode';
+import { extensions, OutputChannel, TerminalOptions, window, workspace } from 'vscode';
 import { LowPassFilter } from './util';
 
 export interface ServerStatus {
@@ -100,8 +100,10 @@ export class Server extends leanclient.Server {
             this.options.push('-T');
             this.options.push('' + config.get('timeLimit'));
 
+            const {extensionPath} = extensions.getExtension('jroesch.lean');
+            const executablePath = this.executablePath.replace('%extensionPath%', extensionPath + '/');
             this.transport = new ProcessTransport(
-                this.executablePath, this.workingDirectory, this.options);
+                executablePath, this.workingDirectory, this.options);
             super.connect();
 
             this.restarted.fire(null);


### PR DESCRIPTION
Per @PatrickMassot's request [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Beer.20reward/near/184393374), this PR adds the ability to use a special token (currently `%extensionPath%`) in the two path settings `lean.executablePath` and `lean.leanpkgPath` which is replaced by the absolute path to the extension directory. 

**Happy to change the syntax, I basically used the first thing that came to mind!**

Other changes:
- In 7ad69c4 fixes a possible typo; I saw a line in `leanpkg.ts` which returns a path ending in `lean` instead of `leanpkg`.
- I updated the instructions for the leanpkg integration in the README; previously it said <kbd>ctrl</kbd>+<kbd>p</kbd>, but this only opens the file search menu. I changed it to <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd>.