### PR TITLE
handle some errors in updateGoal

### DIFF
--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -363,22 +363,26 @@ export class InfoProvider implements Disposable {
     }
 
     private async updateGoal(): Promise<boolean> {
-        if (this.stopped) { return false; }
-        const info = await this.server.info(
-            this.curFileName, this.curPosition.line + 1, this.curPosition.character);
-        if (info.record && info.record.state) {
-            if (this.curGoalState !== info.record.state) {
-                this.curGoalState = info.record.state;
-                return true;
+        if (this.stopped || !this.curFileName || !this.curPosition) { return false; }
+        try {
+            const info = await this.server.info(
+                this.curFileName, this.curPosition.line + 1, this.curPosition.character);
+            if (info.record && info.record.state) {
+                if (this.curGoalState !== info.record.state) {
+                    this.curGoalState = info.record.state;
+                    return true;
+                }
+            } else {
+                if (this.curGoalState) {
+                    this.curGoalState = null;
+                    return false;
+                }
             }
-        } else {
-            if (this.curGoalState) {
-                this.curGoalState = null;
-                return false;
+            if (workspace.getConfiguration('lean').get('typeInStatusBar')) {
+                this.updateTypeStatus(info);
             }
-        }
-        if (workspace.getConfiguration('lean').get('typeInStatusBar')) {
-            this.updateTypeStatus(info);
+        } catch (e) {
+            if (e !== 'interrupted') { throw e; }
         }
     }
 


### PR DESCRIPTION
This PR fixes two sources of unhandled promise rejections in `updateGoal` in `infoview.ts`:
- If the "Lean Messages" info view window is highlighted when the extension is launched (or re-launched during development), errors like the following are logged:
  ```
  rejected promise not handled within 1 second: TypeError: Cannot read property 'line' of null
  extensionHostProcess.js:820
  stack trace: TypeError: Cannot read property 'line' of null
  ...
  ```
  I addressed this by adding a check that `this.curPosition` is not `null`.
- I wrapped the `server.info` call in a `try...catch` block to ignore `interrupted` errors.