### PR TITLE
Bug fixes for tactic suggestions

### DIFF
--- a/src/tacticsuggestions.ts
+++ b/src/tacticsuggestions.ts
@@ -7,8 +7,10 @@ import { InfoProvider } from './infoview';
 /** Pastes suggestions provided by tactics such as `squeeze_simp` */
 export class TacticSuggestions implements Disposable {
     private subscriptions: Disposable[] = [];
+
+    // Match everything after "Try this" until the next unindented line
     private magicWord = 'Try this: ';
-    private regex = '^' + this.magicWord + '(.*)$';
+    private regex = '^' + this.magicWord + '((.*\n )*.*)$';
 
     constructor(private server: Server, private infoView: InfoProvider) {
 

--- a/src/tacticsuggestions.ts
+++ b/src/tacticsuggestions.ts
@@ -72,7 +72,7 @@ export class TacticSuggestions implements Disposable {
         return messages[0];
     }
 
-    private pasteIntoEditor(m : Message, textEditor : TextEditor, suggestion : string | null){
+    private async pasteIntoEditor(m : Message, textEditor : TextEditor, suggestion : string | null){
         if (suggestion === null) {
             // Find first suggestion in message
             suggestion = m.text.match(new RegExp(this.regex, 'm'))[1];
@@ -129,8 +129,13 @@ export class TacticSuggestions implements Disposable {
             new Position(startLine, startCol),
             new Position(endLine, endCol)
         )
-        textEditor.edit(editBuilder => {
+        await textEditor.edit(editBuilder => {
             editBuilder.replace(range, suggestion)
         });
+
+        // Strangely, the cursor moves during the edit, but the selection anchor
+        // does not. Therefore, move the anchor to the cursor:
+        textEditor.selection =
+            new Selection(textEditor.selection.active, textEditor.selection.active);
     }
 }

--- a/src/tacticsuggestions.ts
+++ b/src/tacticsuggestions.ts
@@ -32,7 +32,7 @@ export class TacticSuggestions implements Disposable {
             const newText = text.replace(new RegExp(this.regex, 'mg'), (match,tactic) => {
                 const command = encodeURI('command:_lean.pasteTacticSuggestion?' +
                     JSON.stringify([m, tactic]));
-                return `${this.magicWord}<a href="${command}">${tactic}</a>`
+                return `${this.magicWord}<a href="${command}" title="${tactic}">${tactic}</a>`
             });
             return newText;
         });


### PR DESCRIPTION
* Slightly better tooltips for the links. Unfortunately, I wasn't able to switch them off completely. Any ideas?
* Better heuristic to find the end of the tactic call to replace. I followed Rob's and Mario's suggestions to look for the next unbracketed (comma or semicolon or newline or unmatched closing bracket).
* support multiline suggestions, e.g. from `squeeze_simp`. If there is an indentation after a line break inside a suggestion, it will be considered to be part of the suggestion.