### PR TITLE
Update task config & ignore non-Lean regions of interest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "${defaultBuildTask}"
         },
         {
             "name": "Launch Tests",
@@ -22,7 +22,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
-            "preLaunchTask": "npm"
+            "preLaunchTask": "${defaultBuildTask}"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,30 +1,20 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
 }

--- a/package.json
+++ b/package.json
@@ -467,8 +467,9 @@
 	],
 	"main": "./out/src/extension",
 	"scripts": {
-		"vscode:prepublish": "tsc -p ./",
-		"compile": "tsc -watch -p ./",
+		"vscode:prepublish": "npm run compile",
+		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
 		"lint": "eslint -c .eslintrc.js src/*.ts"
 	},
 	"dependencies": {
@@ -477,6 +478,7 @@
 		"cheerio": "^1.0.0-rc.3",
 		"express": "^4.17.1",
 		"hasbin": "^1.2.3",
+		"lean-client-js-core": "^1.2.12",
 		"lean-client-js-node": "^1.2.12",
 		"load-json-file": "6.2.0",
 		"username": "^5.1.0"

--- a/src/roi.ts
+++ b/src/roi.ts
@@ -93,7 +93,8 @@ export class RoiManager implements Disposable {
             const files = await workspace.findFiles('**/*.lean');
             paths = files.map((f) => f.fsPath);
         } else {
-            paths = workspace.textDocuments.map((d) => d.fileName);
+            paths = workspace.textDocuments.filter((d) => languages.match(this.documentFilter, d))
+                                           .map((d) => d.fileName);
         }
 
         const visibleRanges: {[fileName: string]: RoiRange[]} = {};


### PR DESCRIPTION
Does two small things:
- Brings the `tasks.json` configuration in line with the defaults for VSCode versions post 1.13. I had to do this because of the note [here](https://code.visualstudio.com/docs/editor/tasks#_convert-from-010-to-200) - since version 0.1.0 configurations are ignored in multi-root workspaces, VSCode will literally refuse to debug this extension if I also have a folder with, say, the C++ server open.
- Stops the extension from tracking regions-of-interest on files that aren't written in Lean. Currently, the Lean server stores ROIs for things like `leanpkg.toml`, `README.md`, etc.