### PR TITLE
don't pass negative line numbers to Position

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -31,7 +31,8 @@ export class LeanDiagnosticsProvider implements Disposable {
         const docMap = new Map<string, TextDocument>();
 
         for (const message of messages) {
-            const pos = new Position(message.pos_line - 1, message.pos_col);
+            const line = Math.max(message.pos_line - 1, 0);
+            const pos = new Position(line, message.pos_col);
             // Assign the diagnostic to the entire word following the info message
             // so that code actions can be activated more easily
             let msgDoc = docMap.get(message.file_name);


### PR DESCRIPTION
Currently if you open https://github.com/leanprover-community/lean/blob/master/tests/lean/add_defn_eqns.lean, the Output tab will fill up with messages like "cannot parse ...". There is actually no problem with parsing. The root cause is [this line](https://github.com/leanprover-community/lean/blob/master/tests/lean/add_defn_eqns.lean.expected.out#L37) of the server output:

```
add_defn_eqns.lean:0:0: warning: declaration 'mm' uses sorry
```

The line number is 0, and `diagnostics.ts` subtracts 1 from that before passing it to the Position constructor, which then explodes.

This PR adds a guard which prevents this from happening.