### PR TITLE
Fix issue where it is showing no infos found when it needs to update.

### DIFF
--- a/infoview/event_model.ts
+++ b/infoview/event_model.ts
@@ -127,8 +127,8 @@ export function infoEvents(sb: SignalBuilder, sinks: {onEdit}, onProps: Signal<I
 
     const r: Signal<Partial<InfoState>> = sb.merge(
         result,
-        sb.map<boolean, Partial<InfoState>>(l => ({isLoading:l}), sb.debounce(100, onIsLoading)),
-        sb.map<boolean, Partial<InfoState>>(l => ({isUpdating:l}), sb.debounce(100, isRunning)),
+        sb.map<boolean, Partial<InfoState>>(l => ({isLoading:l}), sb.debounce(300, onIsLoading)),
+        sb.map<boolean, Partial<InfoState>>(l => ({isUpdating:l}), sb.debounce(300, isRunning)),
         onProps,
         we,
         onMessage,

--- a/infoview/event_model.ts
+++ b/infoview/event_model.ts
@@ -60,7 +60,7 @@ export function infoEvents(sb: SignalBuilder, sinks: {onEdit}, onProps: Signal<I
         global_server.error,
         sb.filter(x => !x, onPaused),
         sb.onChange(onIsLoading),
-        sb.onChange(sb.map(isDone, onTasks)),
+        sb.map(isDone, onTasks),
         throttled_loc
     )), onForceUpdate);
 


### PR DESCRIPTION
It happens when the tactic completes too fast and the user types quickly, and so when
lean reports that the task is done, there was no intermediate task reported
so occasionally you would still get no info found bugs.

Right now it is quite jumpy and will flash 'not found' messages on the screen in the case of this bug. 
The long term fix for this is going to be adding a flag to the lean info response saying whether there is no
tactic state or widget because it is loading or because there is nothing there.