### PR TITLE
Remove DisplayMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ This extension contributes the following settings (for a complete list, open the
 It also contributes the following commands, which can be bound to keys if desired:
 
 * `lean.input.convert`: converts the current Unicode abbreviation (bound to <kbd>tab</kbd> by default)
-* `lean.infoView.displayGoal`: show the tactic state and any messages (e.g. info, warning, error) at the current position in the info view window (bound to <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>enter</kbd> by default)
-* `lean.infoView.displayList`: show all messages for the current file from Lean in the info view window (bound to <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>alt</kbd>+<kbd>enter</kbd> by default)
+* `lean.displayGoal`: show the tactic state and any messages (e.g. info, warning, error) at the current position in the info view window (bound to <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>enter</kbd> by default)
 * `lean.infoView.copyToComment`: copy the current contents of the info view into a new comment on the next line (same as clicking on the <img src="media/copy-to-comment.png"> icon)
 * `lean.infoView.toggleStickyPosition`: enable / disable "sticky" mode. On enable this places a marker at the current position, and the goal will continue to be reported from this position even as the cursor moves and edits are made to the file. Disabling the mode goes back to tracking the cursor. (same as clicking on the <img src="media/toggle-sticky-position.png"> icon)
 * `lean.infoView.toggleUpdating`: pause / continue live updates of the info view (same as clicking on the <img src="media/pause.png"> and <img src="media/continue.png"> icons)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ We currently support a variety of features.
 * Error messages / diagnostics
 * Customizable Unicode input support (e.g. type `\la`+<kbd>tab</kbd> to input `λ`)
 * Info view window to show goal, tactic state, and error messages:
-  - click <img src="media/display-goal-light.png"> or hit <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>enter</kbd> for local goal view, or
-  - click <img src="media/display-list-light.png"> or hit <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>alt</kbd>+<kbd>enter</kbd> for all messages
+  click <img src="media/display-goal-light.png"> or hit <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>enter</kbd> for local goal view.
 * Batch file execution
 * Search for declarations in open files (<kbd>ctrl</kbd>+<kbd>p</kbd> `#`)
 * Region of interest checking (i.e. control how much of the project is checked automatically by Lean)
 * Fill in `{! !}` holes with the [code actions](https://code.visualstudio.com/docs/editor/refactoring#_code-actions-quick-fixes-and-refactorings) menu (<kbd>ctrl</kbd>+<kbd>.</kbd>)
 * Tasks for `leanpkg` (<kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> and select "Tasks: Configure Task")
-* Tactic state filtering with regex
 * Type of the term under the cursor can be displayed in the status bar
 * Tactic suggestions (tactics which suggest edits with a "Try this:" message) can be applied either with a keyboard shortcut (<kbd>alt</kbd>+<kbd>v</kbd>), by clicking on the info view message, or via code actions (<kbd>ctrl</kbd>+<kbd>.</kbd>)
 
@@ -52,7 +50,6 @@ This extension contributes the following settings (for a complete list, open the
   - `match` is a boolean, where `true` (`false`) means blocks in the tactic state matching `regex` will be included (excluded) in the info view,
   - `flags` are additional flags passed to the [JavaScript RegExp constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
   - The `name` key is optional and may contain a string that is displayed in the dropdown instead of the full regex details.
-* `lean.infoViewFilterIndex`: index of the filter applied to the tactic state (in the array `lean.infoViewTacticStateFilters`). An index of -1 means no filter is applied.
 * `lean.typeInStatusBar`: controls whether the type of the term under the cursor is displayed as a status bar item (`true` by default).
 * `lean.typesInCompletionList`: controls whether the types of all items in the list of completions are displayed. By default, only the type of the highlighted item is shown.
 

--- a/infoview/index.tsx
+++ b/infoview/index.tsx
@@ -1,7 +1,7 @@
 import { global_server, post, PositionEvent, ConfigEvent, SyncPinEvent, PauseEvent, ContinueEvent, ToggleUpdatingEvent, TogglePinEvent } from './server';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { ServerStatus, Config, defaultConfig,  Location, locationKey, locationEq, DisplayMode } from '../src/shared';
+import { ServerStatus, Config, defaultConfig,  Location, locationKey, locationEq } from '../src/shared';
 import { Message } from 'lean-client-js-core';
 import './tachyons.css' // stylesheet assumed by Lean widgets. See https://tachyons.io/ for documentation
 import './index.css'
@@ -94,7 +94,7 @@ function Main(props: {}) {
                 const isCursor = locationEq(loc,curLoc.loc);
                 return <Info loc={loc} isPaused={paused} setPaused={setPause(i)} key={i} isPinned={true} isCursor={isCursor} onEdit={onEdit} onPin={unpin(i)}/>}) }
             {!isPinned(curLoc.loc) && <Info loc={curLoc.loc} isPaused={curLoc.paused} setPaused={setPause()} key={pinnedLocs.length} isPinned={false} isCursor={true} onEdit={onEdit} onPin={pin}/>}
-            <details className={(config.displayMode === DisplayMode.AllMessage ? '' : 'dn')}>
+            <details>
                 <summary className="mv2">All Messages ({allMessages.length})</summary>
                 <div className="ml1">
                     <Messages messages={allMessages}/>

--- a/infoview/index.tsx
+++ b/infoview/index.tsx
@@ -94,7 +94,7 @@ function Main(props: {}) {
                 const isCursor = locationEq(loc,curLoc.loc);
                 return <Info loc={loc} isPaused={paused} setPaused={setPause(i)} key={i} isPinned={true} isCursor={isCursor} onEdit={onEdit} onPin={unpin(i)}/>}) }
             {!isPinned(curLoc.loc) && <Info loc={curLoc.loc} isPaused={curLoc.paused} setPaused={setPause()} key={pinnedLocs.length} isPinned={false} isCursor={true} onEdit={onEdit} onPin={pin}/>}
-            <details>
+            <details open={!config.infoViewAutoOpenShowGoal}>
                 <summary className="mv2">All Messages ({allMessages.length})</summary>
                 <div className="ml1">
                     <Messages messages={allMessages}/>

--- a/package.json
+++ b/package.json
@@ -103,55 +103,6 @@
 					"default": "",
 					"description": "Add an additional CSS snippet to the info view."
 				},
-				"lean.infoViewTacticStateFilters": {
-					"type": "array",
-					"default": [
-						{
-							"regex": "^_",
-							"match": false,
-							"flags": ""
-						},
-						{
-							"name": "goals only",
-							"regex": "^(⊢|\\d+ goals|case|$)",
-							"match": true,
-							"flags": ""
-						}
-					],
-					"description": "An array of objects containing regular expression strings that can be used to filter (positively or negatively) the tactic state in the info view. Set to an empty array '[]' to hide the filter select dropdown.\n \n Each object must contain the following keys: 'regex': string, 'match': boolean, 'flags': string.\n 'regex' is a properly-escaped regex string,\n 'match' = true (false) means blocks in the tactic state matching 'regex' will be included (excluded) in the info view, \n 'flags' are additional flags passed to the JavaScript RegExp constructor.\n The 'name' key is optional and may contain a string that is displayed in the dropdown instead of the full regex details.",
-					"items": {
-						"type": "object",
-						"description": "an object with required properties 'regex': string, 'match': boolean, and 'flags': string, and optional property 'name': string",
-						"properties": {
-							"name": {
-								"type": "string",
-								"description": "name displayed in the dropdown"
-							},
-							"regex": {
-								"type": "string",
-								"description": "a properly-escaped regex string, e.g. '^_' matches any string beginning with an underscore"
-							},
-							"match": {
-								"type": "boolean",
-								"description": "whether tactic state lines matching the value of 'regex' should be included (true) or excluded (false)"
-							},
-							"flags": {
-								"type": "string",
-								"description": "additional flags passed to the RegExp constructor, e.g. 'i' for ignore case"
-							}
-						},
-						"required": [
-							"regex",
-							"match",
-							"flags"
-						]
-					}
-				},
-				"lean.infoViewFilterIndex": {
-					"type": "number",
-					"default": -1,
-					"description": "Index of the filter applied to the tactic state (in the array infoViewTacticStateFilters). An index of -1 means no filter is applied."
-				},
 				"lean.typeInStatusBar": {
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
 					"default": true,
 					"description": "Info view: open info view when Lean extension is activated."
 				},
+				"lean.infoViewAutoOpenShowGoal": {
+					"type": "boolean",
+					"default": true,
+					"description": "Info view: auto open shows goal and messages for the current line (instead of all messages for the whole file)"
+				},
 				"lean.infoViewStyle": {
 					"type": "string",
 					"default": "",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,55 @@
 					"default": "",
 					"description": "Add an additional CSS snippet to the info view."
 				},
+				"lean.infoViewTacticStateFilters": {
+					"type": "array",
+					"default": [
+						{
+							"regex": "^_",
+							"match": false,
+							"flags": ""
+						},
+						{
+							"name": "goals only",
+							"regex": "^(⊢|\\d+ goals|case|$)",
+							"match": true,
+							"flags": ""
+						}
+					],
+					"description": "An array of objects containing regular expression strings that can be used to filter (positively or negatively) the tactic state in the info view. Set to an empty array '[]' to hide the filter select dropdown.\n \n Each object must contain the following keys: 'regex': string, 'match': boolean, 'flags': string.\n 'regex' is a properly-escaped regex string,\n 'match' = true (false) means blocks in the tactic state matching 'regex' will be included (excluded) in the info view, \n 'flags' are additional flags passed to the JavaScript RegExp constructor.\n The 'name' key is optional and may contain a string that is displayed in the dropdown instead of the full regex details.",
+					"items": {
+						"type": "object",
+						"description": "an object with required properties 'regex': string, 'match': boolean, and 'flags': string, and optional property 'name': string",
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "name displayed in the dropdown"
+							},
+							"regex": {
+								"type": "string",
+								"description": "a properly-escaped regex string, e.g. '^_' matches any string beginning with an underscore"
+							},
+							"match": {
+								"type": "boolean",
+								"description": "whether tactic state lines matching the value of 'regex' should be included (true) or excluded (false)"
+							},
+							"flags": {
+								"type": "string",
+								"description": "additional flags passed to the RegExp constructor, e.g. 'i' for ignore case"
+							}
+						},
+						"required": [
+							"regex",
+							"match",
+							"flags"
+						]
+					}
+				},
+				"lean.infoViewFilterIndex": {
+					"type": "number",
+					"default": -1,
+					"description": "Index of the filter applied to the tactic state (in the array infoViewTacticStateFilters). An index of -1 means no filter is applied."
+				},
 				"lean.typeInStatusBar": {
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -98,11 +98,6 @@
 					"default": true,
 					"description": "Info view: open info view when Lean extension is activated."
 				},
-				"lean.infoViewAutoOpenShowGoal": {
-					"type": "boolean",
-					"default": true,
-					"description": "Info view: auto open shows goal and messages for the current line (instead of all messages for the whole file)"
-				},
 				"lean.infoViewStyle": {
 					"type": "string",
 					"default": "",
@@ -196,36 +191,6 @@
 				"icon": {
 					"dark": "./media/display-goal-dark.svg",
 					"light": "./media/display-goal-light.svg"
-				}
-			},
-			{
-				"command": "lean.displayList",
-				"category": "Lean",
-				"title": "Info View: Display Messages",
-				"description": "Displays all messages for the current file in the info view.",
-				"icon": {
-					"dark": "./media/display-list-dark.svg",
-					"light": "./media/display-list-light.svg"
-				}
-			},
-			{
-				"command": "lean.infoView.displayGoal",
-				"category": "Lean",
-				"title": "Info View: Display Goal",
-				"description": "Display the goal and any messages at the current position in the info view.",
-				"icon": {
-					"dark": "./media/display-goal-dark.svg",
-					"light": "./media/display-goal-light.svg"
-				}
-			},
-			{
-				"command": "lean.infoView.displayList",
-				"category": "Lean",
-				"title": "Info View: Display Messages",
-				"description": "Displays all messages for the current file in the info view.",
-				"icon": {
-					"dark": "./media/display-list-dark.svg",
-					"light": "./media/display-list-light.svg"
 				}
 			},
 			{
@@ -344,12 +309,6 @@
 				"when": "editorTextFocus && editorLangId == lean"
 			},
 			{
-				"command": "lean.displayList",
-				"key": "ctrl+shift+alt+enter",
-				"mac": "cmd+shift+alt+enter",
-				"when": "editorTextFocus && editorLangId == lean"
-			},
-			{
 				"command": "lean.input.convert",
 				"key": "tab",
 				"mac": "tab",
@@ -366,28 +325,12 @@
 				"key": "alt+v",
 				"mac": "alt+v",
 				"when": "editorTextFocus && editorLangId == lean"
-			},
-			{
-				"command": "lean.infoView.displayGoal",
-				"key": "ctrl+shift+enter",
-				"mac": "cmd+shift+enter",
-				"when": "infoViewFocused"
-			},
-			{
-				"command": "lean.infoView.displayList",
-				"key": "ctrl+shift+alt+enter",
-				"mac": "cmd+shift+alt+enter",
-				"when": "infoViewFocused"
 			}
 		],
 		"menus": {
 			"commandPalette": [
 				{
 					"command": "lean.displayGoal",
-					"when": "editorLangId == lean"
-				},
-				{
-					"command": "lean.displayList",
 					"when": "editorLangId == lean"
 				},
 				{
@@ -407,37 +350,14 @@
 					"when": "editorLangId == lean"
 				},
 				{
-					"command": "lean.infoView.displayGoal",
-					"when": "infoViewFocused"
-				},
-				{
-					"command": "lean.infoView.displayList",
-					"when": "infoViewFocused"
-				},
-				{
 					"command": "lean.infoView.toggleUpdating",
 					"when": "editorLangId == lean || infoViewFocused"
 				}
 			],
 			"editor/title": [
 				{
-					"command": "lean.displayList",
-					"when": "editorLangId == lean",
-					"group": "navigation@1"
-				},
-				{
 					"command": "lean.displayGoal",
 					"when": "editorLangId == lean",
-					"group": "navigation@2"
-				},
-				{
-					"command": "lean.infoView.displayList",
-					"when": "infoViewFocused",
-					"group": "navigation@1"
-				},
-				{
-					"command": "lean.infoView.displayGoal",
-					"when": "infoViewFocused",
 					"group": "navigation@2"
 				}
 			]

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -273,6 +273,7 @@ export class InfoProvider implements Disposable {
                 infoViewTacticStateFilters: workspace.getConfiguration('lean').get('infoViewTacticStateFilters', []),
                 filterIndex: workspace.getConfiguration('lean').get('infoViewFilterIndex', -1),
                 infoViewAllErrorsOnLine: workspace.getConfiguration('lean').get('infoViewAllErrorsOnLine', false),
+                infoViewAutoOpenShowGoal: workspace.getConfiguration('lean').get('infoViewAutoOpenShowGoal', true)
             },
         });
     }

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -9,7 +9,7 @@ import {
     Uri, ViewColumn, WebviewPanel, window, workspace,
 } from 'vscode';
 import { Server } from './server';
-import { DisplayMode, ToInfoviewMessage, FromInfoviewMessage, Location, InsertTextMessage, ServerRequestMessage, RevealMessage, HoverPositionMessage, locationEq } from './shared'
+import { ToInfoviewMessage, FromInfoviewMessage, Location, InsertTextMessage, ServerRequestMessage, RevealMessage, HoverPositionMessage, locationEq } from './shared'
 import { StaticServer } from './staticserver';
 
 export class InfoProvider implements Disposable {
@@ -17,8 +17,6 @@ export class InfoProvider implements Disposable {
     private webviewPanel: WebviewPanel;
     private proxyConnection: Connection;
     private subscriptions: Disposable[] = [];
-
-    private displayMode: DisplayMode = DisplayMode.AllMessage;
 
     private statusBarItem: StatusBarItem;
     private statusShown: boolean = false;
@@ -108,19 +106,7 @@ export class InfoProvider implements Disposable {
                 this.postMessage({ command: 'continue' })
             }),
             commands.registerTextEditorCommand('lean.displayGoal', (editor) => {
-                this.setMode(DisplayMode.OnlyState);
                 this.openPreview(editor);
-            }),
-            commands.registerTextEditorCommand('lean.displayList', (editor) => {
-                this.setMode(DisplayMode.AllMessage);
-                this.openPreview(editor);
-            }),
-
-            commands.registerCommand('lean.infoView.displayGoal', () => {
-                this.setMode(DisplayMode.OnlyState);
-            }),
-            commands.registerCommand('lean.infoView.displayList', () => {
-                this.setMode(DisplayMode.AllMessage);
             }),
             commands.registerTextEditorCommand('lean.infoView.copyToComment',() =>
                 this.postMessage({ command: 'copy_to_comment' })
@@ -186,9 +172,6 @@ export class InfoProvider implements Disposable {
     private autoOpen() {
         if (!this.started && workspace.getConfiguration('lean').get('infoViewAutoOpen')) {
             this.started = true;
-            this.setMode(
-                workspace.getConfiguration('lean').get('infoViewAutoOpenShowGoal', true) ?
-                    DisplayMode.OnlyState : DisplayMode.AllMessage);
             this.openPreview(window.activeTextEditor);
             this.sendPosition();
             this.sendConfig();
@@ -201,8 +184,7 @@ export class InfoProvider implements Disposable {
         if (this.webviewPanel) {
             this.webviewPanel.reveal(column, true);
         } else {
-            this.webviewPanel = window.createWebviewPanel('lean',
-                this.displayMode === DisplayMode.OnlyState ? 'Lean Goal' : 'Lean Messages',
+            this.webviewPanel = window.createWebviewPanel('lean', 'Lean Infoview',
                 { viewColumn: column, preserveFocus: true },
                 {
                     enableFindWidget: true,
@@ -291,20 +273,8 @@ export class InfoProvider implements Disposable {
                 infoViewTacticStateFilters: workspace.getConfiguration('lean').get('infoViewTacticStateFilters', []),
                 filterIndex: workspace.getConfiguration('lean').get('infoViewFilterIndex', -1),
                 infoViewAllErrorsOnLine: workspace.getConfiguration('lean').get('infoViewAllErrorsOnLine', false),
-                displayMode: this.displayMode,
             },
         });
-    }
-
-    private setMode(mode: DisplayMode) {
-        if (this.displayMode === mode && !this.stopped) { return; }
-        this.displayMode = mode;
-        if (this.webviewPanel) {
-            this.webviewPanel.title = this.displayMode === DisplayMode.OnlyState ? 'Lean Goal' : 'Lean Messages';
-        }
-        this.stopped = false;
-        this.sendPosition();
-        this.sendConfig();
     }
 
     private async postMessage(msg: ToInfoviewMessage): Promise<boolean> {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -37,11 +37,13 @@ export interface Config {
     filterIndex;
     infoViewTacticStateFilters: any[];
     infoViewAllErrorsOnLine: boolean;
+    infoViewAutoOpenShowGoal: boolean;
 }
 export const defaultConfig: Config = {
     filterIndex: -1,
     infoViewTacticStateFilters: [],
     infoViewAllErrorsOnLine: true,
+    infoViewAutoOpenShowGoal: true,
 }
 
 /** The root state of the infoview */

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -25,11 +25,6 @@ export interface ServerStatus {
     tasks: Task[];
 }
 
-export enum DisplayMode {
-    OnlyState, // only the state at the current cursor position including the tactic state
-    AllMessage, // all messages
-}
-
 export interface InfoProps extends Location {
     widget?: string; // [note] vscode crashes if the widget is sent as a deeply nested json object.
     goalState?: string;
@@ -42,13 +37,11 @@ export interface Config {
     filterIndex;
     infoViewTacticStateFilters: any[];
     infoViewAllErrorsOnLine: boolean;
-    displayMode: DisplayMode;
 }
 export const defaultConfig: Config = {
     filterIndex: -1,
     infoViewTacticStateFilters: [],
     infoViewAllErrorsOnLine: true,
-    displayMode: DisplayMode.AllMessage,
 }
 
 /** The root state of the infoview */


### PR DESCRIPTION
The only thing that DisplayMode was doing was changing the title of infoview and deciding whether or not to display the 'all goals' collapsible section of the infoview. So I think it makes sense to remove it and to also remove the distinction between "Display Goals" and "Display Messages". 

Also remove config to do with filtering hypotheses.