### PR TITLE
Only trigger if location has changed. Fix error updating

### DIFF
--- a/infoview/event_model.ts
+++ b/infoview/event_model.ts
@@ -53,7 +53,7 @@ export function infoEvents(sb: SignalBuilder, onProps: Signal<InfoProps>): Signa
         sb.filter(x => !x, onPaused),
         sb.onChange(onIsLoading),
         sb.map(isDone, onTasks),
-        throttled_loc
+        sb.onChange(throttled_loc, (x,y) => !x || !y || locationKey(x) !== locationKey(y))
     )), onForceUpdate);
     const onMessage = sb.map(({msgs, loc, config}) => {
         return {messages: GetMessagesFor(msgs, loc, config)};

--- a/infoview/event_model.ts
+++ b/infoview/event_model.ts
@@ -61,7 +61,7 @@ export function infoEvents(sb: SignalBuilder, onProps: Signal<InfoProps>): Signa
 
     const {result, isRunning} = sb.throttleTask<Location, Partial<InfoState>>(async () => {
         const loc = onLoc.value;
-        if (!loc) {return {};}
+        if (!loc) {return {widget: null, goalState: null, error: null};}
         try {
             // [todo] if the location has not changed keep the widget and goal state?
             const info = await global_dispatcher.run(() => global_server.info(loc.file_name, loc.line, loc.column));
@@ -72,7 +72,7 @@ export function infoEvents(sb: SignalBuilder, onProps: Signal<InfoProps>): Signa
                 widget.line = loc.line;
                 widget.column = loc.column;
             }
-            return { widget, goalState };
+            return { widget, goalState, error: null };
         } catch (error) {
             return {error};
         }


### PR DESCRIPTION
Fixes an 'error updating' issue on older leans. The problem was that the error flag was not being unset.