### PR TITLE
Fix issue where it would update on scroll

### DIFF
--- a/infoview/event_model.ts
+++ b/infoview/event_model.ts
@@ -44,7 +44,9 @@ export function infoEvents(sb: SignalBuilder, onProps: Signal<InfoProps>): Signa
     sb.store(onPaused);
 
     const throttled_loc = sb.throttle<Location>(300, onLoc);
+    const onLocChange = sb.onChange(throttled_loc, (x,y) => !x || !y || locationKey(x) !== locationKey(y));
     const onTasks = sb.throttle(300, global_server.tasks);
+    const onIsDone = sb.filter(isDone, onTasks);
     const onIsLoading = sb.map(({l, t}) => isLoading(t, l), sb.zip({l:throttled_loc, t:onTasks}));
 
     const updateTrigger = sb.merge(sb.filter((x) => !onPaused.value, sb.merge(
@@ -52,27 +54,35 @@ export function infoEvents(sb: SignalBuilder, onProps: Signal<InfoProps>): Signa
         global_server.error,
         sb.filter(x => !x, onPaused),
         sb.onChange(onIsLoading),
-        sb.map(isDone, onTasks),
-        sb.onChange(throttled_loc, (x,y) => !x || !y || locationKey(x) !== locationKey(y))
+        onLocChange,
     )), onForceUpdate);
+
     const onMessage = sb.map(({msgs, loc, config}) => {
         return {messages: GetMessagesFor(msgs, loc, config)};
     }, sb.zip({msgs: AllMessages, loc: throttled_loc, config: ConfigEvent}));
 
-    const {result, isRunning} = sb.throttleTask<Location, Partial<InfoState>>(async () => {
+    const {result, isRunning} = sb.throttleTask<any, Partial<InfoState>>(async () => {
         const loc = onLoc.value;
+        let maxTries = 2;
         if (!loc) {return {widget: null, goalState: null, error: null};}
         try {
-            // [todo] if the location has not changed keep the widget and goal state?
-            const info = await global_dispatcher.run(() => global_server.info(loc.file_name, loc.line, loc.column));
-            const record = info.record;
-            const goalState = record && record.state;
-            const widget = record && record.widget;
-            if (widget && widget.line === undefined) {
-                widget.line = loc.line;
-                widget.column = loc.column;
+            while (true) {
+                // [todo] if the location has not changed keep the widget and goal state?
+                const info = await global_dispatcher.run(() => global_server.info(loc.file_name, loc.line, loc.column));
+                const record = info.record;
+                const goalState = record && record.state;
+                const widget = record && record.widget;
+                if (widget && widget.line === undefined) {
+                    widget.line = loc.line;
+                    widget.column = loc.column;
+                }
+                if (!widget && !goalState && maxTries > 0) {
+                    await new Promise((res) => setTimeout(res, 100));
+                    maxTries--;
+                } else {
+                    return { widget, goalState, error: null };
+                }
             }
-            return { widget, goalState, error: null };
         } catch (error) {
             return {error};
         }

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -1,4 +1,5 @@
 import { Event } from 'lean-client-js-core'
+import { syncBuiltinESMExports } from 'module';
 
 // https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
 export function escapeHtml(s: string): string {
@@ -122,6 +123,22 @@ export class SignalBuilder {
         return r;
     }
 
+    /** Only trigger the output `y` at most once after each `x` trigger. */
+    onceAfter<X,Y>(x: Signal<X>, y: Signal<Y>): Signal<Y> {
+        const out = new Event<Y>();
+        let trig = false;
+        this.subscriptions.push(
+            x.on(() => {trig = true;}),
+            y.on(v => {
+                if (trig) {
+                    trig = false;
+                    out.fire(v);
+                }
+            }),
+        );
+        return out;
+    }
+
     /** When the input fires, run the given promise and throttle future input values until the promise resolves.
      * Swallows the error if the promise errors.
      */
@@ -182,6 +199,8 @@ export class SignalBuilder {
 
     store<X>(g: Signal<X>): Signal<X> & {value?: X} {
         const r: any = g;
+        if (r.isStoring) {return r;}
+        r.isStoring = true;
         this.subscriptions.push(g.on(x => r.value = x));
         return r;
     }

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -1,5 +1,4 @@
 import { Event } from 'lean-client-js-core'
-import { syncBuiltinESMExports } from 'module';
 
 // https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
 export function escapeHtml(s: string): string {


### PR DESCRIPTION
The problem was that an update was triggering whenever the server sent a message saying that the tasks had all completed.But this was bad because lean would send this eg when the user scrolls. It is too noisy. However this was originally put in to deal with a case where if the info request was too close to the user making a text change,it would _not_ update when it was supposed to because lean would just return `ok` without any info if it was still loading. However because the update was so fast it also wouldn't send a message saying that the cursor position was loading. To fix this, I am just reintroducing the retry loop so that if the server returns ok with no info it just tries again to be sure. I don't think there is a better way of dealing with this case.