### PR TITLE
Support widget trace messages.

### DIFF
--- a/infoview/collapsing.tsx
+++ b/infoview/collapsing.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+
+/** Returns `[node, isVisible]`. Attach `node` to the dom element you care about as `<div ref={node}>...</div>` and
+ * `isVisible` will change depending on whether the node is visible in the viewport or not. */
+export function useIsVisible(): [any, boolean] {
+    const [isVisible,setIsVisible] = React.useState<boolean>(false);
+    const observer = React.useRef<IntersectionObserver>(null);
+    const node = React.useCallback<any>(n => {
+        if (observer.current) {
+            observer.current.disconnect();
+        }
+        if (n !== null) {
+            // this is called when the given element is mounted.
+            observer.current = new IntersectionObserver(([x]) => {
+                setIsVisible(x.isIntersecting);
+            }, { threshold: 0, root: null, rootMargin: '0px'});
+            observer.current.observe(n);
+        } else {
+            // when unmounted
+        }
+    }, []);
+    return [node, isVisible]
+}

--- a/infoview/info.tsx
+++ b/infoview/info.tsx
@@ -67,7 +67,13 @@ export function Info(props: InfoProps) {
                 </span>
             </summary>
             <div className="ml1">
-                {!loading && !updating && updateError && <div className="error">Error updating: {updateError.message}. <a className="link pointer dim" onClick={e => forceUpdate()}>Try again.</a></div> }
+                <div>
+                    {!loading && !updating && updateError &&
+                        <div className="error">
+                            Error updating: {updateError.message}.
+                            <a className="link pointer dim" onClick={e => forceUpdate()}>Try again.</a>
+                        </div> }
+                </div>
                 <div>
                     <Widget widget={widget} fileName={loc.file_name} onEdit={onEdit} />
                 </div>

--- a/infoview/messages.tsx
+++ b/infoview/messages.tsx
@@ -1,9 +1,10 @@
 import { basename, escapeHtml, colorizeMessage } from './util';
-import { Message } from 'lean-client-js-node';
+import { Message, WidgetIdentifier } from 'lean-client-js-node';
 import * as React from 'react';
 import { Location, Config } from '../src/shared';
 import { CopyToCommentIcon, GoToFileIcon } from './svg_icons';
 import { post } from './server';
+import { Widget } from './widget';
 
 function compareMessages(m1: Message, m2: Message): boolean {
     return (m1.file_name === m2.file_name &&
@@ -25,6 +26,7 @@ export function MessageView(props: MessageViewProps) {
     let text = escapeHtml(m.text)
     text = shouldColorize ? colorizeMessage(text) : text;
     const title = `${b}:${l}:${c}`;
+    const widgetId: WidgetIdentifier | null = (m as any).widget;
     return <details open>
         <summary className={m.severity + ' mv2 pointer'}>{title}
                 <span className="fr">
@@ -33,7 +35,9 @@ export function MessageView(props: MessageViewProps) {
                 </span>
         </summary>
         <div className="ml1">
+            { widgetId ? <Widget fileName={m.file_name} widget={widgetId}/> :
             <pre className="font-code" style={{whiteSpace: 'pre-wrap'}} dangerouslySetInnerHTML={{ __html: text }} />
+            }
         </div>
     </details>
 }

--- a/infoview/messages.tsx
+++ b/infoview/messages.tsx
@@ -26,7 +26,6 @@ export function MessageView(props: MessageViewProps) {
     let text = escapeHtml(m.text)
     text = shouldColorize ? colorizeMessage(text) : text;
     const title = `${b}:${l}:${c}`;
-    const widgetId: WidgetIdentifier | null = (m as any).widget;
     return <details open>
         <summary className={m.severity + ' mv2 pointer'}>{title}
                 <span className="fr">
@@ -35,7 +34,7 @@ export function MessageView(props: MessageViewProps) {
                 </span>
         </summary>
         <div className="ml1">
-            { widgetId ? <Widget fileName={m.file_name} widget={widgetId}/> :
+            { m.widget ? <Widget fileName={m.file_name} widget={m.widget}/> :
             <pre className="font-code" style={{whiteSpace: 'pre-wrap'}} dangerouslySetInnerHTML={{ __html: text }} />
             }
         </div>

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -4,6 +4,7 @@ import './popper.css';
 import { WidgetComponent, WidgetHtml, WidgetElement, WidgetEventRequest, WidgetIdentifier } from 'lean-client-js-node';
 import { global_server } from './server';
 import { Location } from '../src/shared';
+import { useIsVisible } from './collapsing';
 
 function Popper(props: {children: React.ReactNode[], popperContent: any, refEltTag: any, refEltAttrs: any}) {
     const { children, popperContent, refEltTag, refEltAttrs } = props;
@@ -58,28 +59,6 @@ class WidgetErrorBoundary extends React.Component<{children: any},{error?: {mess
       }
       return this.props.children;
     }
-}
-
-/** Returns `[node, isVisible]`. Attach `node` to the dom element you care about as `<div ref={node}>...</div>` and
- * `isVisible` will change depending on whether the node is visible in the viewport or not. */
-export function useIsVisible(): [any, boolean] {
-    const [isVisible,setIsVisible] = React.useState<boolean>(false);
-    const observer = React.useRef<IntersectionObserver>(null);
-    const node = React.useCallback<any>(n => {
-        if (observer.current) {
-            observer.current.disconnect();
-        }
-        if (n !== null) {
-            // this is called when the given element is mounted.
-            observer.current = new IntersectionObserver(([x]) => {
-                setIsVisible(x.isIntersecting);
-            }, { threshold: 0, root: null, rootMargin: '0px'});
-            observer.current.observe(n);
-        } else {
-            // when unmounted
-        }
-    }, []);
-    return [node, isVisible]
 }
 
 export function Widget({ widget, fileName, onEdit }: WidgetProps): JSX.Element {

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -6,7 +6,7 @@ import { global_server } from './server';
 import { Location } from '../src/shared';
 import { useIsVisible } from './collapsing';
 
-function Popper(props: {children: React.ReactNode[], popperContent: any, refEltTag: any, refEltAttrs: any}) {
+function Popper(props: {children: React.ReactNode[]; popperContent: any; refEltTag: any; refEltAttrs: any}) {
     const { children, popperContent, refEltTag, refEltAttrs } = props;
     const [referenceElement, setReferenceElement] = React.useState(null);
     const [popperElement, setPopperElement] = React.useState(null);

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -5,7 +5,7 @@ import { WidgetComponent, WidgetHtml, WidgetElement, WidgetEventRequest, WidgetI
 import { global_server } from './server';
 import { Location } from '../src/shared';
 
-const Popper = (props) => {
+function Popper(props: {children: React.ReactNode[], popperContent: any, refEltTag: any, refEltAttrs: any}) {
     const { children, popperContent, refEltTag, refEltAttrs } = props;
     const [referenceElement, setReferenceElement] = React.useState(null);
     const [popperElement, setPopperElement] = React.useState(null);
@@ -34,7 +34,7 @@ export interface WidgetProps {
     fileName: string;
 }
 
-class WidgetErrorBoundary extends React.Component<{children},{error}> {
+class WidgetErrorBoundary extends React.Component<{children: any},{error?: {message: string}}> {
     constructor(props) {
       super(props);
       this.state = { error: null };
@@ -62,7 +62,7 @@ class WidgetErrorBoundary extends React.Component<{children},{error}> {
 
 /** Returns `[node, isVisible]`. Attach `node` to the dom element you care about as `<div ref={node}>...</div>` and
  * `isVisible` will change depending on whether the node is visible in the viewport or not. */
-function useIsVisible() {
+export function useIsVisible(): [any, boolean] {
     const [isVisible,setIsVisible] = React.useState<boolean>(false);
     const observer = React.useRef<IntersectionObserver>(null);
     const node = React.useCallback<any>(n => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3871,9 +3871,9 @@
 			}
 		},
 		"lean-client-js-core": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-1.4.0.tgz",
-			"integrity": "sha512-eyFEI61fUJ+cweRjw3UmGAkxH1QUFXM+FGsmkzVuN8qf4lvjrtL11vUGr6Y/StxT0iRAcv8dAY9ScIRQZjWgJA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lean-client-js-core/-/lean-client-js-core-1.5.0.tgz",
+			"integrity": "sha512-1uQ+ldW85sMW1zvwab424qGM1bDwJ2d51qcUt5bxWPIp9Zef7pcqRhYytAvxj1G1+4+gZhUzbyHS7wfh7bRrcg==",
 			"requires": {
 				"@types/node": "^9.4.6"
 			},
@@ -3886,12 +3886,12 @@
 			}
 		},
 		"lean-client-js-node": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-1.4.0.tgz",
-			"integrity": "sha512-Vu2Czgj/ol4luBR9W3amGJefLB600NpX4igyjNGXI+0pLxVkItnTGfQ6doNRDrLAG7FMb7z7IFx7NZzE8iVXrQ==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lean-client-js-node/-/lean-client-js-node-1.5.0.tgz",
+			"integrity": "sha512-1Vx4huU6FCN1ZNNbTghXlJKQH1RoxhNnQCTxRkeFRUkDyM5p7BYn8XuCMacwuiDH21y1NEP7BNbiyNBXCULMWA==",
 			"requires": {
 				"@types/node": "^9.4.6",
-				"lean-client-js-core": "^1.4.0"
+				"lean-client-js-core": "^1.5.0"
 			},
 			"dependencies": {
 				"@types/node": {

--- a/package.json
+++ b/package.json
@@ -396,8 +396,8 @@
 		"cheerio": "^1.0.0-rc.3",
 		"express": "^4.17.1",
 		"hasbin": "^1.2.3",
-		"lean-client-js-core": "^1.4.0",
-		"lean-client-js-node": "^1.4.0",
+		"lean-client-js-core": "^1.5.0",
+		"lean-client-js-node": "^1.5.0",
 		"load-json-file": "6.2.0",
 		"username": "^5.1.0"
 	},


### PR DESCRIPTION
There are still some performance problems.  In particular, all widgets in the messages are rendered at all times...

@EdAyers Do you know if there is a standard way to make `<details>` only render (on the react side) the visible elements?