### PR TITLE
Widgets only fetch widget info when they are visible in the viewport.

### DIFF
--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -84,7 +84,6 @@ function useIsVisible() {
 
 export function Widget({ widget, fileName, onEdit }: WidgetProps): JSX.Element {
     const [html, setHtml] = React.useState<WidgetComponent>();
-    const widgetContainerRef = React.useRef(null);
     const [node, isVisible] = useIsVisible();
     React.useEffect(() => {
         if (!isVisible) {return; }
@@ -128,9 +127,10 @@ export function Widget({ widget, fileName, onEdit }: WidgetProps): JSX.Element {
             console.error(`Update gave an error: ${record.message || record}`);
         }
     }
-    return <div ref={node} className={isVisible ? 'ba b--red' : 'ba b--green'}><WidgetErrorBoundary>
-        { html ? <ViewHtml html={html} post={post}/> : null }
-    </WidgetErrorBoundary>
+    return <div ref={node}>
+        <WidgetErrorBoundary>
+            { html ? <ViewHtml html={html} post={post}/> : null }
+        </WidgetErrorBoundary>
     </div>
 }
 


### PR DESCRIPTION
Fix performance issue where many messages with widgets would impact performance. Now it will only ask the server for widget info when it becomes visible in the viewport. So this also means that if there is a very long list of messages, opening the All Messages view should remain performant because it will only load widgets for messages that are scrolled in to view. 