### PR TITLE
Reduce updates

### DIFF
--- a/infoview/collapsing.tsx
+++ b/infoview/collapsing.tsx
@@ -21,3 +21,16 @@ export function useIsVisible(): [any, boolean] {
     }, []);
     return [node, isVisible]
 }
+
+export function Details({open: initiallyOpen, children: [summary, ...children]}: {open?: boolean; children: [JSX.Element, ...JSX.Element[]]}): JSX.Element {
+    const [isOpen, setOpen] = React.useState<boolean>(initiallyOpen === undefined ? true : false);
+    const setupEventListener = React.useCallback((node?: HTMLDetailsElement) => {
+        if (node !== null) {
+            node.addEventListener('toggle', () => setOpen(node.open));
+        }
+    }, []);
+    return <details ref={setupEventListener} open={initiallyOpen}>
+        {summary}
+        { isOpen && children }
+    </details>;
+}

--- a/infoview/event_model.ts
+++ b/infoview/event_model.ts
@@ -1,6 +1,6 @@
 import { Signal, SignalBuilder } from './util';
 import { Event, CurrentTasksResponse, GoalState, Message, WidgetIdentifier } from 'lean-client-js-core'
-import { global_server, ServerRestartEvent, ConfigEvent, AllMessages } from './server';
+import { global_server, ServerRestartEvent, ConfigEvent, AllMessagesEvent } from './server';
 import {Location, locationKey,} from '../src/shared';
 import { GetMessagesFor } from './messages';
 import * as React from 'react';
@@ -59,7 +59,7 @@ export function infoEvents(sb: SignalBuilder, onProps: Signal<InfoProps>): Signa
 
     const onMessage = sb.map(({msgs, loc, config}) => {
         return {messages: GetMessagesFor(msgs, loc, config)};
-    }, sb.zip({msgs: AllMessages, loc: throttled_loc, config: ConfigEvent}));
+    }, sb.zip({msgs: AllMessagesEvent, loc: throttled_loc, config: ConfigEvent}));
 
     const {result, isRunning} = sb.throttleTask<any, Partial<InfoState>>(async () => {
         const loc = onLoc.value;

--- a/infoview/goal.tsx
+++ b/infoview/goal.tsx
@@ -8,9 +8,9 @@ interface GoalProps {
 
 export function Goal(props: GoalProps): JSX.Element {
     const config = React.useContext(ConfigContext);
-    if (!props.goalState) { return null; }
     const reFilters = config.infoViewTacticStateFilters || [];
     const [filterIndex, setFilterIndex] = React.useState(config.filterIndex ?? -1);
+    if (!props.goalState) { return null; }
     let goalString = props.goalState.replace(/^(no goals)/mg, 'goals accomplished')
     goalString = RegExp('^\\d+ goals|goals accomplished', 'mg').test(goalString) ? goalString : '1 goal\n'.concat(goalString);
     if (!(reFilters.length === 0 || filterIndex === -1)) {

--- a/infoview/index.tsx
+++ b/infoview/index.tsx
@@ -51,13 +51,6 @@ function Main(props: {}) {
             setPinnedLocs(pins);
         }
     }
-    function onEdit(loc: Location, text: string) {
-        return post({
-            command: 'insert_text',
-            loc,
-            text
-        });
-    }
     React.useEffect(() => {
         const subscriptions = [
             AllMessages.on(x => setMessages(x)),
@@ -92,8 +85,8 @@ function Main(props: {}) {
         <ConfigContext.Provider value={config}>
             {pinnedLocs.map(({loc, paused},i) => {
                 const isCursor = locationEq(loc,curLoc.loc);
-                return <Info loc={loc} isPaused={paused} setPaused={setPause(i)} key={i} isPinned={true} isCursor={isCursor} onEdit={onEdit} onPin={unpin(i)}/>}) }
-            {!isPinned(curLoc.loc) && <Info loc={curLoc.loc} isPaused={curLoc.paused} setPaused={setPause()} key={pinnedLocs.length} isPinned={false} isCursor={true} onEdit={onEdit} onPin={pin}/>}
+                return <Info loc={loc} isPaused={paused} setPaused={setPause(i)} key={i} isPinned={true} isCursor={isCursor} onPin={unpin(i)}/>}) }
+            {!isPinned(curLoc.loc) && <Info loc={curLoc.loc} isPaused={curLoc.paused} setPaused={setPause()} key={pinnedLocs.length} isPinned={false} isCursor={true} onPin={pin}/>}
             <details open={!config.infoViewAutoOpenShowGoal}>
                 <summary className="mv2">All Messages ({allMessages.length})</summary>
                 <div className="ml1">

--- a/infoview/index.tsx
+++ b/infoview/index.tsx
@@ -80,7 +80,7 @@ function Main(props: {}) {
         setPinnedLocs(pins);
         post({command:'sync_pin', pins: pins.map(x => x.loc)})
     }
-    const allMessages = processMessages(messages, null);
+    const allMessages = processMessages(messages.filter((m) => !curLoc.loc || m.file_name === curLoc.loc.file_name));
     return <div className="ma1">
         <ConfigContext.Provider value={config}>
             {pinnedLocs.map(({loc, paused},i) => {

--- a/infoview/index.tsx
+++ b/infoview/index.tsx
@@ -1,4 +1,4 @@
-import { global_server, post, PositionEvent, ConfigEvent, SyncPinEvent, PauseEvent, ContinueEvent, ToggleUpdatingEvent, TogglePinEvent, AllMessages } from './server';
+import { post, PositionEvent, ConfigEvent, SyncPinEvent, PauseEvent, ContinueEvent, ToggleUpdatingEvent, TogglePinEvent, AllMessagesEvent } from './server';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { ServerStatus, Config, defaultConfig,  Location, locationKey, locationEq } from '../src/shared';
@@ -7,12 +7,13 @@ import './tachyons.css' // stylesheet assumed by Lean widgets. See https://tachy
 import './index.css'
 import { Info } from './info';
 import { Messages, processMessages } from './messages';
+import { Details } from './collapsing';
 
 export const ConfigContext = React.createContext<Config>(defaultConfig);
 export const LocationContext = React.createContext<Location | null>(null);
 
 function StatusView(props: ServerStatus) {
-    return <details open>
+    return <Details>
         <summary className="mv2 pointer">Tasks</summary>
         <p>Running: {props.isRunning}</p>
         <table> <tbody>
@@ -28,7 +29,7 @@ function StatusView(props: ServerStatus) {
             </tr>)}
         </tbody>
         </table>
-    </details>
+    </Details>
 }
 
 interface InfoProps {
@@ -41,7 +42,25 @@ function Main(props: {}) {
     const [config, setConfig] = React.useState(defaultConfig);
     const [messages, setMessages] = React.useState<Message[]>([]);
     const [curLoc, setCurLoc] = React.useState<InfoProps>({paused: false});
-    const [pinnedLocs, setPinnedLocs] = React.useState<InfoProps[]>([]);
+    React.useEffect(() => {
+        const subscriptions = [
+            AllMessagesEvent.on(x => setMessages(x)),
+            PositionEvent.on(loc => setCurLoc({...curLoc, loc})),
+            ConfigEvent.on(l => setConfig(l)),
+        ];
+
+        return () => { for (const s of subscriptions) s.dispose(); }
+    }, []);
+    const allMessages = processMessages(messages.filter((m) => !curLoc.loc || m.file_name === curLoc.loc.file_name));
+    return <div className="ma1">
+        <ConfigContext.Provider value={config}>
+            <Infos curLoc={curLoc} setCurLoc={setCurLoc}/>
+            <div className="mv2"><AllMessages allMessages={allMessages}/></div>
+        </ConfigContext.Provider>
+    </div>
+}
+
+function Infos({curLoc, setCurLoc}): JSX.Element {
     const setPause = (idx?: number) => (paused: boolean) => {
         if (idx === undefined) {
             setCurLoc({...curLoc, paused});
@@ -53,9 +72,6 @@ function Main(props: {}) {
     }
     React.useEffect(() => {
         const subscriptions = [
-            AllMessages.on(x => setMessages(x)),
-            PositionEvent.on(loc => setCurLoc({...curLoc, loc})),
-            ConfigEvent.on(l => setConfig(l)),
             SyncPinEvent.on(l => setPinnedLocs(l.pins.map((loc, i) => ({loc, paused: pinnedLocs[i] && pinnedLocs[i].paused})))),
             PauseEvent.on(l => setPause()(true)),
             ContinueEvent.on(l => setPause()(false)),
@@ -65,6 +81,7 @@ function Main(props: {}) {
 
         return () => { for (const s of subscriptions) s.dispose(); }
     }, []);
+    const [pinnedLocs, setPinnedLocs] = React.useState<InfoProps[]>([]);
     const isPinned = (loc: Location) => pinnedLocs.some(l => locationEq(l.loc, loc));
     const pin = () => {
         if (isPinned(curLoc.loc)) {return; }
@@ -80,21 +97,23 @@ function Main(props: {}) {
         setPinnedLocs(pins);
         post({command:'sync_pin', pins: pins.map(x => x.loc)})
     }
-    const allMessages = processMessages(messages.filter((m) => !curLoc.loc || m.file_name === curLoc.loc.file_name));
-    return <div className="ma1">
-        <ConfigContext.Provider value={config}>
-            {pinnedLocs.map(({loc, paused},i) => {
-                const isCursor = locationEq(loc,curLoc.loc);
-                return <Info loc={loc} isPaused={paused} setPaused={setPause(i)} key={i} isPinned={true} isCursor={isCursor} onPin={unpin(i)}/>}) }
-            {!isPinned(curLoc.loc) && <Info loc={curLoc.loc} isPaused={curLoc.paused} setPaused={setPause()} key={pinnedLocs.length} isPinned={false} isCursor={true} onPin={pin}/>}
-            <details open={!config.infoViewAutoOpenShowGoal}>
-                <summary className="mv2">All Messages ({allMessages.length})</summary>
-                <div className="ml1">
-                    <Messages messages={allMessages}/>
-                </div>
-            </details>
-        </ConfigContext.Provider>
-    </div>
+    return <>
+        {pinnedLocs.map(({loc, paused}, i) => {
+            const isCursor = locationEq(loc,curLoc.loc);
+            return <Info key={locationKey(loc)} loc={loc} isPaused={paused} setPaused={setPause(i)} isPinned={true} isCursor={isCursor} onPin={unpin(i)}/>}) }
+        <div>
+            {!isPinned(curLoc.loc) &&
+                <Info loc={curLoc.loc} isPaused={curLoc.paused} setPaused={setPause()} key={pinnedLocs.length} isPinned={false} isCursor={true} onPin={pin}/>}
+        </div>
+    </>;
+}
+
+function AllMessages({allMessages}): JSX.Element {
+    const config = React.useContext(ConfigContext);
+    return <Details open={!config.infoViewAutoOpenShowGoal}>
+        <summary>All Messages ({allMessages.length})</summary>
+        <div className="ml1"> <Messages messages={allMessages}/> </div>
+    </Details>;
 }
 
 const domContainer = document.querySelector('#react_root');

--- a/infoview/info.tsx
+++ b/infoview/info.tsx
@@ -1,6 +1,6 @@
 import { Location } from '../src/shared';
 import * as React from 'react';
-import { post, CopyToCommentEvent } from './server';
+import { post, CopyToCommentEvent, copyToComment } from './server';
 import { LocationContext, ConfigContext } from '.';
 import { Widget } from './widget';
 import { Goal } from './goal';
@@ -22,27 +22,25 @@ interface InfoProps {
     loc: Location;
     isPinned: boolean;
     isCursor: boolean;
-    onEdit: (l: Location, text: string) => void;
     onPin: (new_pin_state: boolean) => void;
     isPaused: boolean;
     setPaused: (paused: boolean) => void;
 }
 
 export function Info(props: InfoProps) {
-    const {setPaused, onPin, onEdit, isCursor, isPinned} = props;
+    const {setPaused, onPin, isCursor, isPinned} = props;
     const {loc, isLoading:loading, isUpdating:updating, isPaused: paused, error:updateError, goalState, widget, messages, forceUpdate} = useInfo(props);
     const config    = React.useContext(ConfigContext);
 
-    function copyToComment(text?: string) {
-        if (!(text || goalState)) { return; }
-        post({ command: 'insert_text', text: `/-\n${text || goalState}\n-/\n`})
+    function copyGoalToComment() {
+        if (goalState) copyToComment(goalState);
     }
 
     // If we are the cursor infoview, then we should subscribe to
     // some commands from the extension
     React.useEffect(() => {
         if (isCursor) {
-            const h = CopyToCommentEvent.on(copyToComment);
+            const h = CopyToCommentEvent.on(copyGoalToComment);
             return () => h.dispose();
         }
     }, [isCursor]);
@@ -59,7 +57,7 @@ export function Info(props: InfoProps) {
             <summary style={{transition: 'color 0.5s ease'}} className={'mv2 ' + statusColor}>
                 {locationString}
                 <span className="fr">
-                    {goalState && <a className="link pointer mh2 dim" title="copy state to comment" onClick={e => {e.preventDefault(); copyToComment()}}><CopyToCommentIcon/></a>}
+                    {goalState && <a className="link pointer mh2 dim" title="copy state to comment" onClick={e => {e.preventDefault(); copyGoalToComment()}}><CopyToCommentIcon/></a>}
                     {isPinned && <a className={'link pointer mh2 dim '} onClick={e => { e.preventDefault(); post({command: 'reveal', loc}); }} title="reveal file location"><GoToFileIcon/></a>}
                     <a className="link pointer mh2 dim" onClick={e => { e.preventDefault(); onPin(!isPinned)}} title={isPinned ? 'unpin' : 'pin'}>{isPinned ? <PinnedIcon/> : <PinIcon/>}</a>
                     <a className="link pointer mh2 dim" onClick={e => { e.preventDefault(); setPaused(!paused)}} title={paused ? 'continue updating' : 'pause updating'}>{paused ? <ContinueIcon/> : <PauseIcon/>}</a>
@@ -75,7 +73,7 @@ export function Info(props: InfoProps) {
                         </div> }
                 </div>
                 <div>
-                    <Widget widget={widget} fileName={loc.file_name} onEdit={onEdit} />
+                    <Widget widget={widget} fileName={loc.file_name} />
                 </div>
                 <details open={!widget} className={goalState ? '' : 'dn'}>
                     <summary className="mv2 pointer">{widget ? 'Plaintext Tactic State' : 'Tactic State'}</summary>
@@ -86,7 +84,7 @@ export function Info(props: InfoProps) {
                 <details open className={messages.length === 0 ? 'dn' : '0'}>
                     <summary className="mv2 pointer">Messages ({messages.length})</summary>
                     <div className="ml1">
-                        <Messages messages={messages} onCopyToComment={copyToComment}/>
+                        <Messages messages={messages}/>
                     </div>
                 </details>
                 {nothingToShow && (

--- a/infoview/info.tsx
+++ b/infoview/info.tsx
@@ -8,6 +8,7 @@ import { Messages, processMessages } from './messages';
 import { basename } from './util';
 import { CopyToCommentIcon, PinnedIcon, PinIcon, ContinueIcon, PauseIcon, RefreshIcon, GoToFileIcon } from './svg_icons';
 import { useInfo } from './event_model';
+import { Details } from './collapsing';
 
 type InfoStatus = 'updating' | 'error' | 'pinned' | 'cursor' | 'loading';
 
@@ -30,7 +31,6 @@ interface InfoProps {
 export function Info(props: InfoProps) {
     const {setPaused, onPin, isCursor, isPinned} = props;
     const {loc, isLoading:loading, isUpdating:updating, isPaused: paused, error:updateError, goalState, widget, messages: messages0, forceUpdate} = useInfo(props);
-    const config    = React.useContext(ConfigContext);
     const messages = processMessages(messages0);
 
     function copyGoalToComment() {
@@ -54,7 +54,7 @@ export function Info(props: InfoProps) {
     const nothingToShow = !widget && !goalState && messages.length === 0;
     const locationString = `${basename(loc.file_name)}:${(loc).line}:${(loc).column}`;
     return <LocationContext.Provider value={loc}>
-        <details className="" open>
+        <Details>
             <summary style={{transition: 'color 0.5s ease'}} className={'mv2 ' + statusColor}>
                 {locationString}
                 <span className="fr">
@@ -93,7 +93,7 @@ export function Info(props: InfoProps) {
                     paused ? <span>Updating is paused. <a className="link pointer dim" onClick={e => forceUpdate()}>Refresh</a> or <a className="link pointer dim" onClick={e => setPaused(false)}>resume updating</a> to see information</span> :
                     `No info found at ${locationString}`)}
             </div>
-        </details>
+        </Details>
     </LocationContext.Provider>;
 }
 

--- a/infoview/info.tsx
+++ b/infoview/info.tsx
@@ -4,7 +4,7 @@ import { post, CopyToCommentEvent, copyToComment } from './server';
 import { LocationContext, ConfigContext } from '.';
 import { Widget } from './widget';
 import { Goal } from './goal';
-import { Messages } from './messages';
+import { Messages, processMessages } from './messages';
 import { basename } from './util';
 import { CopyToCommentIcon, PinnedIcon, PinIcon, ContinueIcon, PauseIcon, RefreshIcon, GoToFileIcon } from './svg_icons';
 import { useInfo } from './event_model';
@@ -29,8 +29,9 @@ interface InfoProps {
 
 export function Info(props: InfoProps) {
     const {setPaused, onPin, isCursor, isPinned} = props;
-    const {loc, isLoading:loading, isUpdating:updating, isPaused: paused, error:updateError, goalState, widget, messages, forceUpdate} = useInfo(props);
+    const {loc, isLoading:loading, isUpdating:updating, isPaused: paused, error:updateError, goalState, widget, messages: messages0, forceUpdate} = useInfo(props);
     const config    = React.useContext(ConfigContext);
+    const messages = processMessages(messages0);
 
     function copyGoalToComment() {
         if (goalState) copyToComment(goalState);

--- a/infoview/messages.tsx
+++ b/infoview/messages.tsx
@@ -18,8 +18,7 @@ interface MessageViewProps {
     m: Message;
 }
 
-export function MessageView(props: MessageViewProps) {
-    const {m} = props;
+const MessageView = React.memo(({m}: MessageViewProps) => {
     const b = escapeHtml(basename(m.file_name));
     const l = m.pos_line; const c = m.pos_col;
     const loc: Location = {file_name: m.file_name, column: c, line: l}
@@ -40,7 +39,7 @@ export function MessageView(props: MessageViewProps) {
             }
         </div>
     </details>
-}
+}, (a,b) => compareMessages(a.m, b.m));
 
 interface MessagesProps {
     messages: ProcessedMessage[];
@@ -64,10 +63,9 @@ export function processMessages(messages: Message[]): ProcessedMessage[] {
     return messages
         .sort((a, b) => a.pos_line === b.pos_line ? a.pos_col - b.pos_col : a.pos_line - b.pos_line)
         .map((m) => {
-            let key = `${m.pos_line}:${m.pos_col}`;
-            keys[key] += 1;
-            key = `${key}:${keys[key]}`;
-            return {...m, key};
+            const key0 = `${m.pos_line}:${m.pos_col}`;
+            keys[key0] = (keys[key0] || 0)+1;
+            return { ...m, key: `${key0}:${keys[key0]}` };
         });
 }
 

--- a/infoview/server.ts
+++ b/infoview/server.ts
@@ -33,7 +33,7 @@ export const ToggleUpdatingEvent: Event<{}> = new Event();
 export const CopyToCommentEvent: Event<{}> = new Event();
 export const TogglePinEvent: Event<{}> = new Event();
 export const ServerRestartEvent: Event<{}> = new Event();
-export const AllMessages: Event<Message[]> = new Event();
+export const AllMessagesEvent: Event<Message[]> = new Event();
 
 window.addEventListener('message', event => { // messages from the extension
     const message: ToInfoviewMessage = event.data; // The JSON data our extension sent
@@ -47,7 +47,7 @@ window.addEventListener('message', event => { // messages from the extension
         case 'copy_to_comment': CopyToCommentEvent.fire(message); break;
         case 'toggle_pin': TogglePinEvent.fire(message); break;
         case 'restart': ServerRestartEvent.fire(message); break;
-        case 'all_messages': AllMessages.fire(message.messages); break;
+        case 'all_messages': AllMessagesEvent.fire(message.messages); break;
         case 'server_event': break;
         case 'server_error': break;
     }
@@ -106,7 +106,7 @@ class ProxyConnectionClient implements Connection {
 
 export const global_server = new Server(new ProxyTransport());
 global_server.logMessagesToConsole = true;
-global_server.allMessages.on(x => AllMessages.fire(x.msgs));
+global_server.allMessages.on(x => AllMessagesEvent.fire(x.msgs));
 global_server.connect();
 
 post({command:'request_config'});

--- a/infoview/server.ts
+++ b/infoview/server.ts
@@ -8,6 +8,18 @@ export function post(message: FromInfoviewMessage) { // send a message to the ex
     vscode.postMessage(message);
 }
 
+export function copyToComment(text: string) {
+    post({ command: 'insert_text', text: `/-\n${text}\n-/\n`});
+}
+
+export function reveal(loc: Location) {
+    post({ command: 'reveal', loc });
+}
+
+export function edit(loc: Location, text: string) {
+    post({ command: 'insert_text', loc, text });
+}
+
 export const PositionEvent: Event<Location> = new Event();
 const InnerConfigEvent: Event<Partial<Config>> = new Event();
 export const ConfigEvent: Signal<Config> = (new SignalBuilder()).scan((acc, x) => ({...acc, ...x}), defaultConfig, InnerConfigEvent);

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 import * as ReactPopper from 'react-popper';
 import './popper.css';
 import { WidgetComponent, WidgetHtml, WidgetElement, WidgetEventRequest, WidgetIdentifier } from 'lean-client-js-node';
-import { global_server } from './server';
-import { Location } from '../src/shared';
+import { global_server, edit } from './server';
 import { useIsVisible } from './collapsing';
 
 function Popper(props: {children: React.ReactNode[]; popperContent: any; refEltTag: any; refEltAttrs: any}) {
@@ -31,7 +30,6 @@ function Popper(props: {children: React.ReactNode[]; popperContent: any; refEltT
 
 export interface WidgetProps {
     widget?: WidgetIdentifier;
-    onEdit?: (l: Location, text: string) => void;
     fileName: string;
 }
 
@@ -61,7 +59,7 @@ class WidgetErrorBoundary extends React.Component<{children: any},{error?: {mess
     }
 }
 
-export function Widget({ widget, fileName, onEdit }: WidgetProps): JSX.Element {
+export function Widget({ widget, fileName }: WidgetProps): JSX.Element {
     const [html, setHtml] = React.useState<WidgetComponent>();
     const [node, isVisible] = useIsVisible();
     React.useEffect(() => {
@@ -98,7 +96,7 @@ export function Widget({ widget, fileName, onEdit }: WidgetProps): JSX.Element {
             setHtml(record.widget.html);
         } else if (record.status === 'edit') {
             const loc = { line: widget.line, column: widget.column, file_name: fileName };
-            if (onEdit) onEdit(loc, record.action);
+            edit(loc, record.action);
             setHtml(record.widget.html);
         } else if (record.status === 'invalid_handler') {
             console.warn(`No widget_event update for ${message.handler}: invalid handler.`)

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -59,7 +59,7 @@ class WidgetErrorBoundary extends React.Component<{children: any},{error?: {mess
     }
 }
 
-export function Widget({ widget, fileName }: WidgetProps): JSX.Element {
+export const Widget = React.memo(({ widget, fileName }: WidgetProps) => {
     const [html, setHtml] = React.useState<WidgetComponent>();
     const [node, isVisible] = useIsVisible();
     React.useEffect(() => {
@@ -109,7 +109,13 @@ export function Widget({ widget, fileName }: WidgetProps): JSX.Element {
             { html ? <ViewHtml html={html} post={post}/> : null }
         </WidgetErrorBoundary>
     </div>
-}
+}, (a, b) => a.fileName === b.fileName &&
+    !!a.widget === !!b.widget &&
+    (!a.widget || a.widget === b.widget ||
+        a.widget.line === b.widget.line &&
+        a.widget.column === b.widget.column &&
+        a.widget.id === b.widget.id &&
+        a.widget.html === b.widget.html));
 
 interface HtmlProps {
     html: WidgetComponent;

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -61,9 +61,7 @@ class WidgetErrorBoundary extends React.Component<{children: any},{error?: {mess
 
 export const Widget = React.memo(({ widget, fileName }: WidgetProps) => {
     const [html, setHtml] = React.useState<WidgetComponent>();
-    const [node, isVisible] = useIsVisible();
     React.useEffect(() => {
-        if (!isVisible) {return; }
         async function loadHtml() {
             setHtml((await global_server.send({
                 command: 'get_widget',
@@ -78,7 +76,7 @@ export const Widget = React.memo(({ widget, fileName }: WidgetProps) => {
         } else {
             setHtml(widget && widget.html);
         }
-    }, [fileName, widget, isVisible]);
+    }, [fileName, widget]);
     if (!widget) return null;
     async function post(e: any) {
         const message: WidgetEventRequest = {
@@ -104,7 +102,7 @@ export const Widget = React.memo(({ widget, fileName }: WidgetProps) => {
             console.error(`Update gave an error: ${record.message || record}`);
         }
     }
-    return <div ref={node}>
+    return <div>
         <WidgetErrorBoundary>
             { html ? <ViewHtml html={html} post={post}/> : null }
         </WidgetErrorBoundary>


### PR DESCRIPTION
Make the info view only request widgets that are visible and haven't changed.

- Use memoization for the widget component.
- Add a `<Details>` component that works just like `<details>` except that the contents are only rendered if it is expanded.