### PR TITLE
upload .vsix package as artifact

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -12,3 +12,7 @@ jobs:
       - run: npm run lint
       - run: npm run compile
       - run: npm run package
+      - uses: actions/upload-artifact@v2
+        with:
+          name: vscode-lean
+          path: 'lean-*.vsix'


### PR DESCRIPTION
Since we're already creating the .vsix package as part of CI, we should make it available as an artifact.