### PR TITLE
Support setting custom translations to be null.

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -3,7 +3,7 @@ import { CancellationToken, commands, Disposable, DocumentFilter, Hover,
     TextDocumentChangeEvent, TextEditor, TextEditorDecorationType,
     TextEditorSelectionChangeEvent, window, workspace } from 'vscode';
 
-export interface Translations { [abbrev: string]: string }
+export interface Translations { [abbrev: string]: string | null }
 
 function inputModeEnabled(): boolean {
     return workspace.getConfiguration('lean.input').get('enabled', true);
@@ -42,7 +42,8 @@ export class LeanInputExplanationHover implements HoverProvider, Disposable {
         this.reverseTranslations = {};
         const allTranslations = { ...this.translations, ...customTranslations };
         for (const abbrev of Object.getOwnPropertyNames(allTranslations)) {
-            const unicode = allTranslations[abbrev];
+            const unicode: string | null = allTranslations[abbrev];
+            if (!unicode) { continue; }
             if (!this.reverseTranslations[unicode]) {
                 this.reverseTranslations[unicode] = [];
             }


### PR DESCRIPTION
This means that now you can set eg `"_": null` in
`lean.input.customTranslations` and the system will _not_ complete `\_`
to `ₐ` or whatever is the first in the iteration order of the
translations file.

See https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/how.20to.20write.20a.20superscript.20quickly.3F