### PR TITLE
Revert infoview:getMediaPath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,6 +1596,13 @@
 				"semver": "^5.5.0",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"crypto-browserify": {
@@ -3696,6 +3703,14 @@
 			"requires": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"map-age-cleaner": {
@@ -4372,6 +4387,14 @@
 			"dev": true,
 			"requires": {
 				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"parse5": {
@@ -5105,9 +5128,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+			"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -6158,6 +6181,14 @@
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
 				"yazl": "^2.2.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"warning": {

--- a/package.json
+++ b/package.json
@@ -409,6 +409,7 @@
 		"lean-client-js-core": "^1.5.0",
 		"lean-client-js-node": "^1.5.0",
 		"load-json-file": "6.2.0",
+		"semver": "^7.3.2",
 		"username": "^5.1.0"
 	},
 	"devDependencies": {

--- a/src/docview.ts
+++ b/src/docview.ts
@@ -22,7 +22,7 @@ export class DocViewProvider implements Disposable {
     private currentURL: string | undefined = undefined;
     private backstack: string[] = [];
     private forwardstack: string[] = [];
-    constructor(private staticServer: StaticServer) {
+    constructor(private staticServer?: StaticServer) {
         this.subscriptions.push(
             commands.registerCommand('lean.openDocView', (url) => this.open(url)),
             commands.registerCommand('lean.backDocView', () => this.back()),
@@ -126,8 +126,12 @@ export class DocViewProvider implements Disposable {
                 return '';
             }
             const path = Uri.parse(uri.toString()).fsPath;
-            // workaround for https://github.com/microsoft/vscode/issues/89038
-            return this.staticServer.mkUri(path);
+            if (this.staticServer) {
+                // workaround for https://github.com/microsoft/vscode/issues/89038
+                return this.staticServer.mkUri(path);
+            } else {
+                return this.webview.webview.asWebviewUri(Uri.parse(uri.toString())).toString();
+            }
         } else {
             return uri.toString();
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,8 +111,8 @@ export function activate(context: ExtensionContext): void {
         // Tactic suggestions
         context.subscriptions.push(new TacticSuggestions(server, infoView, LEAN_MODE));
     }
-    // https://github.com/microsoft/vscode/issues/89038 fixed in 1.46
-    if (semver.gte(version, '1.46.0')) {
+    // https://github.com/microsoft/vscode/issues/89038 fixed in 1.47
+    if (semver.gte(version, '1.47.0')) {
         waitStaticServer();
     } else {
         staticServer = new StaticServer(context);

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -28,7 +28,7 @@ export class InfoProvider implements Disposable {
 
     private hoverDecorationType: TextEditorDecorationType;
 
-    constructor(private server: Server, private leanDocs: DocumentSelector, private context: ExtensionContext, private staticServer: StaticServer) {
+    constructor(private server: Server, private leanDocs: DocumentSelector, private context: ExtensionContext, private staticServer?: StaticServer) {
 
         this.statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 1000);
 
@@ -344,8 +344,13 @@ export class InfoProvider implements Disposable {
     }
 
     private getMediaPath(mediaFile: string): string {
-        // workaround for https://github.com/microsoft/vscode/issues/89038
-        return this.staticServer.mkUri(join(this.context.extensionPath, 'media', mediaFile));
+        if (this.staticServer) {
+            // workaround for https://github.com/microsoft/vscode/issues/89038
+            return this.staticServer.mkUri(join(this.context.extensionPath, 'media', mediaFile));
+        } else {
+            return this.webviewPanel.webview.asWebviewUri(
+                Uri.file(join(this.context.extensionPath, 'media', mediaFile))).toString();
+        }
     }
 
     private initialHtml() {


### PR DESCRIPTION
Revert getMediaPath method to the one used in v0.15.5
This allows the info view to work in vscode remote fixing #208