### PR TITLE
Add support for Unicode input with multiple cursors

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,6 +332,12 @@
 				"when": "editorTextFocus && editorLangId == lean && lean.input.isActive"
 			},
 			{
+				"command": "lean.input.convertWithNewline",
+				"key": "enter",
+				"mac": "enter",
+				"when": "editorTextFocus && editorLangId == lean && lean.input.isActive && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible && !vim.active || vim.mode == 'Insert' "
+			},
+			{
 				"command": "lean.batchExecute",
 				"key": "ctrl+shift+r",
 				"mac": "cmd+shift+r",

--- a/src/input.ts
+++ b/src/input.ts
@@ -80,14 +80,14 @@ export class LeanInputExplanationHover implements HoverProvider, Disposable {
 }
 /* Each editor has their own abbreviation handler. */
 class TextEditorAbbrevHandler {
-    range: Range | undefined;
+    ranges: (Range | undefined)[] = [];
 
     constructor(public editor: TextEditor, private abbreviator: LeanInputAbbreviator) {}
 
-    private async updateRange(range?: Range) {
-        if (range && !range.isSingleLine) { range = null; }
-        this.range = range;
-        this.editor.setDecorations(this.abbreviator.decorationType, range ? [range] : []);
+    private async updateRanges(ranges: Range[]) {
+        this.ranges = ranges;
+
+        this.editor.setDecorations(this.abbreviator.decorationType, ranges);
         await this.abbreviator.updateInputActive();
 
         // HACK: support \{{}} and \[[]]
@@ -99,94 +99,85 @@ class TextEditorAbbrevHandler {
             [this.leader + 'f<>']: '‹›',
             [this.leader + 'f<<>>']: '«»',
         };
-        if (range) {
-            const replacement = hackyReplacements[this.editor.document.getText(range)];
-            if (replacement) {
-                await this.editor.edit((builder) => {
+
+        await this.editor.edit((builder) => {
+            ranges.forEach(range => {
+                const replacement = hackyReplacements[this.editor.document.getText(range)];
+
+                if(replacement) {
                     builder.replace(range, replacement);
                     const pos = range.start.translate(0, 1);
                     this.editor.selection = new Selection(pos, pos);
-                    void this.updateRange();
-                });
-            }
-        }
+                }
+            })
+        })
     }
 
     get leader(): string { return this.abbreviator.leader; }
     get enabled(): boolean { return this.abbreviator.enabled; }
 
-    get rangeSize(): number {
-        return this.range.end.character - this.range.start.character;
-    }
+    async convertRanges(trailingLeader: boolean = false) {
+        const newRanges : Range[] = [];
 
-    async convertRange(newRange?: Range) {
-        if (!this.range || this.rangeSize < 2) { return this.updateRange(); }
+        await this.editor.edit((builder) => {
+            this.ranges.forEach(range => {
+                const toReplace = this.editor.document.getText(range);
 
-        const range = this.range;
+                const abbreviation = toReplace.slice(1);
+                const replacement = toReplace.startsWith(this.leader) && this.abbreviator.findReplacement(abbreviation);
 
-        const toReplace = this.editor.document.getText(range);
-        if (!toReplace.startsWith(this.leader)) { return this.updateRange(); }
-
-        const abbreviation = toReplace.slice(1);
-        const replacement = this.abbreviator.findReplacement(abbreviation);
-
-        if (replacement) {
-            setTimeout(async () => {
-                // Without the timeout hack, inserting `\delta ` at the beginning of an
-                // existing line would leave the cursor four characters too far right.
-                await this.editor.edit((builder) => builder.replace(range, replacement));
-                if (newRange) {
-                    await this.updateRange(new Range(
-                        newRange.start.translate(0, replacement.length - toReplace.length),
-                        newRange.end.translate(0, replacement.length - toReplace.length)));
+                if(replacement) builder.replace(range, replacement)
+                if(trailingLeader) {
+                    newRanges.push(new Range(
+                        range.end.translate(0, replacement.length - (toReplace.length + 1)),
+                        range.end.translate(0, replacement.length - toReplace.length)
+                    ))
                 }
-            }, 0);
-        }
+            })
+        })
 
-        await this.updateRange(newRange);
+        await this.updateRanges(newRanges);
     }
 
-    async onChanged(ev: TextDocumentChangeEvent) {
-        if (ev.contentChanges.length === 0) {
+    async onChanged({ contentChanges: changes }: TextDocumentChangeEvent) {
+        if (changes.length === 0) {
             // This event is triggered by files.autoSave=onDelay
             return;
         }
-        if (ev.contentChanges.length !== 1) { return this.updateRange(); } // single change
-        const change = ev.contentChanges[0];
 
-        if (change.text.length === 1 || change.text === '\r\n') {
-            // insert (or right paren overwriting)
-            if (!this.range) {
-                if (change.text === this.leader) {
-                    return this.updateRange(new Range(change.range.start, change.range.start.translate(0, 1)));
-                }
-            } else if (change.range.start.isEqual(this.range.end)) {
-                if (change.text === this.leader && this.rangeSize === 1) {
-                    await this.updateRange();
-                    return this.editor.edit((builder) =>
-                        builder.delete(new Range(change.range.start, change.range.end.translate(0, 1))));
-                } else if (change.text === this.leader) {
-                    return this.convertRange(
-                        new Range(change.range.start, change.range.start.translate(0, 1)));
-                } else if (/^\s+$/.exec(change.text)) {
-                    // whitespace
-                    return this.convertRange();
-                }
+        const ranges : Range[] = []
+        let isInsert : boolean
+
+        changes.forEach(change => {
+            const existingRange = this.ranges.find(range => range.contains(change.range) && range.start.isBefore(change.range.start));
+
+            // insert
+            if (!existingRange && change.text === this.leader) {
+                ranges.push(new Range(change.range.start, change.range.start.translate(0, 1)));
+                isInsert = true;
             }
-        }
 
-        if (this.range && this.range.contains(change.range) && this.range.start.isBefore(change.range.start)) {
-            // modification
-            return this.updateRange(new Range(this.range.start,
-                this.range.end.translate(0, change.text.length - change.rangeLength)));
-        }
+            if (existingRange) {
+                // modification
+                ranges.push(new Range(existingRange.start,
+                    existingRange.end.translate(0, change.text.length - change.rangeLength)));
+            }
+        })
 
-        await this.updateRange();
+        await this.updateRanges(ranges)
+
+        if(!isInsert && changes.every(change => /^\s+$/.exec(change.text) || change.text === this.leader)) {
+            await this.convertRanges(changes[0].text === this.leader);
+        }
     }
 
     async onSelectionChanged(ev: TextEditorSelectionChangeEvent) {
-        if (ev.selections.length !== 1 || !this.range || !this.range.contains(ev.selections[0].active)) {
-            await this.convertRange();
+        const rangesUnselected = this.ranges.every(range => {
+            return !ev.selections.some(selection => range.contains(selection.active))
+        })
+
+        if (rangesUnselected) {
+            await this.convertRanges();
         }
     }
 }
@@ -230,8 +221,17 @@ export class LeanInputAbbreviator {
         this.subscriptions.push(commands.registerTextEditorCommand('lean.input.convert', async (editor, edit) => {
             const handler = this.handlers.get(editor);
             if (handler) {
-                await handler.convertRange();
+                await handler.convertRanges();
             }
+        }));
+
+        this.subscriptions.push(commands.registerTextEditorCommand('lean.input.convertWithNewline', async (editor) => {
+            const handler = this.handlers.get(editor);
+            if (handler) {
+                await handler.convertRanges();
+            }
+
+            return commands.executeCommand('type', { source: 'keyboard', text: '\n' });
         }));
 
         this.subscriptions.push(workspace.onDidChangeConfiguration(() => {
@@ -249,7 +249,7 @@ export class LeanInputAbbreviator {
 
     get active(): boolean {
         const handler = this.handlers.get(window.activeTextEditor);
-        return handler && !!handler.range;
+        return handler && (handler.ranges.length > 0);
     }
 
     async updateInputActive(): Promise<void> {


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/636814/89900068-25fed580-dbdb-11ea-9140-2c5c5d837f67.gif" width=200>

<img src="https://user-images.githubusercontent.com/636814/89900081-2ac38980-dbdb-11ea-8510-1f976315c6ff.gif" width=400>

Add support for multiple cursors for Unicode input, closes #160 🙂. I've tested the following cases with single and multiple cursors:

- Using <kbd>Tab</kbd> key
- Using <kbd>Return</kbd> key
- Moving outside of range to be converted (e.g. with mouse or arrow keys)
- Typing a space
- Typing another <kbd>\\</kbd>

To accomplish multiple cursor support I replace `TextEditorAbbrevHandler.range` with `TextEditorAbbrevHandler.ranges` (any array of `Range`s) - otherwise the logic remains mostly the same.

#### Notes

- ~~In the current version there's slightly odd behaviour where if you type <kbd>\\\\</kbd> it get collapsed into <kbd>\\</kbd> (but only once, additional <kbd>\\</kbd>s appear as normal). This was due to the lines:~~

  ```js
  if (change.text === this.leader && this.rangeSize === 1) {
      await this.updateRange();
      return this.editor.edit((builder) =>
          builder.delete(new Range(change.range.start, change.range.end.translate(0, 1))));
  }
  ```

  ~~I'm not sure why this would be intended behaviour, so I've scrapped it for now.~~ **Edit:** Old behaviour restored

- `convertRange()` (now `convertRanges()`) currently wraps the replacement operation in a timeout with the comment:

  ```js
  // Without the timeout hack, inserting `\delta ` at the beginning of an
  // existing line would leave the cursor four characters too far right.
  ```

  I haven't been able to replicate this, so I've ditched the timeout.


#### Caveats

- "Hacky replacements" (⦃⦄, ⟦⟧ etc.) work with multiple cursors. However, getting all the cursors positioned inside the brackets after insertion would I think be a bit of a headache - so right now you just end up with a single cursor in the first pair of brackets:

  <img src="https://user-images.githubusercontent.com/636814/89900614-dff64180-dbdb-11ea-9d2b-51ed70346a73.gif" width=200>