### PR TITLE
Add support for katex.

### DIFF
--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -5,6 +5,7 @@ import './popper.css';
 import { WidgetComponent, WidgetHtml, WidgetElement, WidgetEventRequest, WidgetIdentifier } from 'lean-client-js-node';
 import { global_server, edit, reveal, highlightPosition, clearHighlight, copyText } from './server';
 
+import 'katex/dist/katex.min.css';
 import * as Katex from 'react-katex';
 
 /** Certain tags given by the lean widget code should be rendered as special components.

--- a/infoview/widget.tsx
+++ b/infoview/widget.tsx
@@ -5,6 +5,16 @@ import './popper.css';
 import { WidgetComponent, WidgetHtml, WidgetElement, WidgetEventRequest, WidgetIdentifier } from 'lean-client-js-node';
 import { global_server, edit, reveal, highlightPosition, clearHighlight, copyText } from './server';
 
+import * as Katex from 'react-katex';
+
+/** Certain tags given by the lean widget code should be rendered as special components.
+ * When rendering an element, this dictionary is first checked.
+ */
+const tagComponentDictionary = {
+    'InlineMath': Katex.InlineMath,
+    'BlockMath': Katex.BlockMath,
+}
+
 function Popper(props: {children: React.ReactNode[]; popperContent: any; refEltTag: any; refEltAttrs: any}) {
     const { children, popperContent, refEltTag, refEltAttrs } = props;
     const [referenceElement, setReferenceElement] = React.useState(null);
@@ -172,9 +182,11 @@ function ViewHtml(props: {html: WidgetHtml; post: (msg: any) => void}) {
 
 function ViewWidgetElement(props: {w: WidgetElement; post: (msg: any) => void}) {
     const {w, post, ...rest} = props;
-    const { t:tag, c:children, tt:tooltip } = w;
+    const { c:children, tt:tooltip } = w;
+    let tag = w.t;
     let { a:attributes, e:events } = w;
-    if (tag === 'hr') { return <hr />; }
+    if (tag === 'hr') { return <hr/>; }
+    tag = tagComponentDictionary[tag] || tag;
     attributes = attributes || {};
     events = events || {};
     const new_attrs: any = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,8 +1408,7 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -3567,6 +3566,14 @@
 				}
 			}
 		},
+		"katex": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+			"integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
+			"requires": {
+				"commander": "^2.19.0"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3756,6 +3763,11 @@
 					"dev": true
 				}
 			}
+		},
+		"match-at": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/match-at/-/match-at-0.1.1.tgz",
+			"integrity": "sha512-h4Yd392z9mST+dzc+yjuybOGFNOZjmXIPKWjxBd1Bb23r4SmDOsk2NYCU2BMUBGbSpZqwVsZYNq26QS3xfaT3Q=="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -4773,6 +4785,24 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true
+		},
+		"react-katex": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/react-katex/-/react-katex-2.0.2.tgz",
+			"integrity": "sha512-mk1ezfUF4mBIstjvpfELf9g1rWF1Y1+idXMiOvkFvCLi0JFZDCQdui59VqQcI2ynOpb0jj52TM4kyBjKG+qEBg==",
+			"requires": {
+				"katex": "^0.9.0"
+			},
+			"dependencies": {
+				"katex": {
+					"version": "0.9.0",
+					"resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
+					"integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
+					"requires": {
+						"match-at": "^0.1.1"
+					}
+				}
+			}
 		},
 		"react-popper": {
 			"version": "2.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6134,6 +6134,17 @@
 			"integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
 			"dev": true
 		},
+		"url-loader": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-4.1.0.tgz",
+			"integrity": "sha512-IzgAAIC8wRrg6NYkFIJY09vtktQcsvU8V6HhtQj9PTefbYImzLB1hufqo4m+RyM5N3mLx5BqJKccgxJS+W3kqw==",
+			"dev": true,
+			"requires": {
+				"loader-utils": "^2.0.0",
+				"mime-types": "^2.1.26",
+				"schema-utils": "^2.6.5"
+			}
+		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -412,9 +412,11 @@
 		"cheerio": "^1.0.0-rc.3",
 		"express": "^4.17.1",
 		"hasbin": "^1.2.3",
+		"katex": "^0.12.0",
 		"lean-client-js-core": "^1.5.0",
 		"lean-client-js-node": "^1.5.0",
 		"load-json-file": "6.2.0",
+		"react-katex": "^2.0.2",
 		"semver": "^7.3.2",
 		"username": "^5.1.0"
 	},

--- a/package.json
+++ b/package.json
@@ -443,6 +443,7 @@
 		"svg-loader": "0.0.2",
 		"ts-loader": "^6.2.1",
 		"typescript": "^3.9.6",
+		"url-loader": "^4.1.0",
 		"vsce": "^1.77.0",
 		"webpack": "^4.41.6",
 		"webpack-cli": "^3.3.12"

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -362,7 +362,6 @@ export class InfoProvider implements Disposable {
                 <meta http-equiv="Content-type" content="text/html;charset=utf-8">
                 <title>Infoview</title>
                 <style>${this.stylesheet}</style>
-                <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
             </head>
             <body>
                 <div id="react_root"></div>

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -362,6 +362,7 @@ export class InfoProvider implements Disposable {
                 <meta http-equiv="Content-type" content="text/html;charset=utf-8">
                 <title>Infoview</title>
                 <style>${this.stylesheet}</style>
+                <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
             </head>
             <body>
                 <div id="react_root"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,13 @@ function getWebviewConfig(env) {
 				{
 					test: /\.svg/,
 					use: ['svg-loader']
-				}
+				},
+				{
+					test: /\.(woff|woff2|ttf)$/,
+					use: {
+					  loader: 'url-loader',
+					},
+				},
 			]
 		},
 		resolve: {


### PR DESCRIPTION
The design is that now if the user uses the special tags `InlineMath` or `BlockMath`, as in;
```
#html (h "BlockMath" [attr.val "math" "f(x) = \\int_{-\\infty}^\\infty \\hat f(\\xi)\\,e^{2 \\pi i \\xi x} \\,d\\xi"] [])
```
Then vscode will catch it and turn it in to a component. The component list is stored in a javascript object called `tagComponentDict`.
This does make the lean <-> vscode interface more complicated, because now lean is assuming that the widget renderer knows to render InlineMath and BlockMath as katex components.
So for example if someone wanted to write thier own widget renderer, there are now more assumptions that they need to be aware of.
However in the case of some key libraries like D3 and Katex I think this is not too great a sacrifice since the only widgets client at the moment is the vscode extension. Also adding this feature doesn't require any changes in core or break existing widgets in any way.

It would be nice at some point to have Lean be able to programmatically say which libraries it wants, but for now this will do.
Alternatively, at some point we should standardise which libraries and CSS classes lean expects to be available.

~~The style sheet for katex is loaded from a CDN instead of using webpack, because it was easier and less bloaty than getting webpack to include the font files.~~