### PR TITLE
remove leading and trailing whitespace from suggestions

### DIFF
--- a/src/tacticsuggestions.ts
+++ b/src/tacticsuggestions.ts
@@ -69,6 +69,8 @@ export class TacticSuggestions implements Disposable, CodeActionProvider {
             if (!suggs) return;
             suggestion = suggs[1];
         }
+        // remove leading and trailing whitespace
+        suggestion = suggestion.trim();
 
         // Start of the tactic call to replace
         const startLine = m.pos_line - 1;

--- a/src/trythis.ts
+++ b/src/trythis.ts
@@ -1,5 +1,5 @@
 // Match everything after "Try this" until the next unindented line
-export const magicWord = 'Try this: ';
+export const magicWord = 'Try this:';
 export const regex = '^' + magicWord + '((.*\n )*.*)$';
 export const regexGM = new RegExp(regex, 'gm');
 export const regexM = new RegExp(regex, 'm');


### PR DESCRIPTION
This PR should improve support for multi-line suggestions. However, we might want to make more extensive changes to the suggestion format as well, e.g. wrap the suggestions in HTML tags so they look nicer in widget mode.

See https://github.com/leanprover-community/mathlib/pull/4093#issuecomment-692202104.