### PR TITLE
Add lean syntax highlighting in markdown codeblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,6 +310,12 @@
 				"language": "leanmarkdown",
 				"scopeName": "source.lean.markdown",
 				"path": "./syntaxes/lean-markdown.json"
+			},
+			{
+				"scopeName": "markdown.lean.codeblock",
+				"path": "./syntaxes/codeblock.json",
+				"injectTo": ["text.html.markdown"],
+				"embeddedLanguages": {"meta.embedded.block.lean":"lean"}
 			}
 		],
 		"keybindings": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#lean-code-block"
+		}
+	],
+	"repository": {
+		"lean-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(lean)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language"
+				},
+				"6": {
+					"name": "fenced_code.block.language.attributes"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.lean",
+					"patterns": [
+						{
+							"include": "source.lean"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.lean.codeblock"
+}


### PR DESCRIPTION
Enables lean syntax highlighting in markdown files.

![image](https://user-images.githubusercontent.com/5064353/98291638-5ae4b380-1fa3-11eb-8e1c-e2c151e9a4f1.png)

Based on https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example