### PR TITLE
Configure VS Code to start the watch task (rather than the build task) when debugging the extension.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "stopOnEntry": false,
             "sourceMaps": true,
             "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
-            "preLaunchTask": "${defaultBuildTask}"
+            "preLaunchTask": "watch"
         },
         {
             "name": "Launch Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
 			"label": "watch",
 			"type": "npm",
 			"script": "watch",
-			"problemMatcher": "$tsc-watch",
+			"problemMatcher": "$ts-webpack-watch",
 			"isBackground": true,
 			"presentation": {
 				"reveal": "never"
@@ -18,7 +18,7 @@
 			"label": "compile",
 			"type": "npm",
 			"script": "compile",
-			"problemMatcher": "$tsc",
+			"problemMatcher": "$ts-webpack",
 			"presentation": {
 				"reveal": "never"
 			},

--- a/package.json
+++ b/package.json
@@ -417,7 +417,7 @@
 	"scripts": {
 		"vscode:prepublish": "webpack --env.production",
 		"compile": "webpack --env.development",
-		"watch": "webpack --env.development --watch",
+		"watch": "webpack --env.development --watch --info-verbosity verbose",
 		"lint": "eslint -c ./.eslintrc.js ./src/**/*.ts ./infoview/**/*.tsx",
 		"package": "vsce package"
 	},


### PR DESCRIPTION
This requires [this extension](https://marketplace.visualstudio.com/items?itemName=eamodio.tsl-problem-matcher) though to detect when webpack has finished building the output.

See #242.