### PR TITLE
fix when condition for lean.input.convertWithNewline

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,7 +345,7 @@
 				"command": "lean.input.convertWithNewline",
 				"key": "enter",
 				"mac": "enter",
-				"when": "editorTextFocus && editorLangId == lean && lean.input.isActive && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible && (!vim.active || vim.mode == 'Insert')"
+				"when": "editorTextFocus && editorLangId == lean && lean.input.isActive && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible && !vim.active || editorTextFocus && editorLangId == lean && lean.input.isActive && !suggestWidgetVisible && !renameInputVisible && !inSnippetMode && !quickFixWidgetVisible && vim.mode == 'Insert'"
 			},
 			{
 				"command": "lean.batchExecute",


### PR DESCRIPTION
The current `when` condition for `lean.input.convertWithNewline` has parentheses in it which corrupts the keybinding setting, cf. https://github.com/microsoft/vscode/issues/91473

