### PR TITLE
use URI file instead of path so that the scheme gets set properly on windows

### DIFF
--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -200,7 +200,7 @@ export class InfoProvider implements Disposable {
                 this.handleServerRequest(message);
                 return;
             case 'reveal':
-                await this.revealEditorPosition(Uri.parse(message.loc.file_name), message.loc.line, message.loc.column);
+                await this.revealEditorPosition(Uri.file(message.loc.file_name), message.loc.line, message.loc.column);
                 return;
             case 'sync_pin':
                 this.pins = message.pins;


### PR DESCRIPTION
Go to defintion via widgets was broken for me before this change

The doc at
https://github.com/microsoft/vscode-uri
implies that we should not make this change if we make use of query fragments (i.e. "https://code.visualstudio.com/docs/extensions/overview#fragment") but I don't believe that we do.
Testing on linux/mac would be great, and if anyone who uses some remote development set-up can test that would also be cool!