### PR TITLE
fix(syntaxes/lean): do not match `forall₂` and other tokens beginning with keywords as binder introductions

### DIFF
--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -134,7 +134,7 @@
         { "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+))\\b", "name": "constant.numeric.lean" },
 
         {
-          "begin": "\\b(?<!\\.)(fun|forall|assume|exists|λ)(?!\\.)\\b", "end": ",",
+          "begin": "\\b(?<!\\.)(fun|forall|assume|exists|λ)(?![_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ&&[^λΠΣ]])", "end": ",",
           "beginCaptures": {"0": {"name": "keyword.other.lean"}},
           "comment": "Binders to show in blue.",
           "patterns": [
@@ -224,15 +224,18 @@
       ]
     },
     "definitionName": {
+      "comment": "This regex matches the lean3 parser implementation here: https://github.com/leanprover-community/lean/blob/65ad4ffdb3abac75be748554e3cbe990fb1c6500/src/util/name.cpp#L28-L56",
       "patterns": [
-        {"match": "\\b[^:«»\\(\\)\\{\\}⦃⦄,[:space:]=→λ∀?][^:«»\\(\\)\\{\\}⦃⦄,[:space:]]*", "name": "entity.name.function.lean"},
-        {"begin": "«", "end": "»", "contentName": "entity.name.function.lean"}
+        { "match": "\\b[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟&&[^λΠΣ]][_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ&&[^λΠΣ]]*",
+          "name": "entity.name.function.lean"},
+        { "begin": "«", "end": "»", "contentName": "entity.name.function.lean"}
       ]
     },
     "binderName": {
       "patterns": [
-        {"match": "\\b[^:«»\\(\\)\\{\\}⦃⦄,[:space:]=→λ∀?][^:«»\\(\\)\\{\\}⦃⦄,[:space:]]*", "name": "variable.parameter.lean"},
-        {"begin": "«", "end": "»", "contentName": "variable.parameter.lean"}
+        { "match": "\\b[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟&&[^λΠΣ]][_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ&&[^λΠΣ]]*",
+          "name": "variable.parameter.lean"},
+        { "begin": "«", "end": "»", "contentName": "variable.parameter.lean"}
       ]
     },
     "binders": {


### PR DESCRIPTION
This fixes bad highlighting in data/list/forall2

cc @b-mehta.