### PR TITLE
fix(syntaxes/lean): `exists` is not a binder if followed by a dot

### DIFF
--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -135,7 +135,7 @@
         { "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+))\\b", "name": "constant.numeric.lean" },
 
         {
-          "begin": "\\b(?<!\\.)(fun|forall|assume|exists|λ)(?!(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])", "end": ",|=>",
+          "begin": "\\b(?<!\\.)(fun|forall|assume|exists|λ)(?!\\.(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])", "end": ",|=>",
           "beginCaptures": {"0": {"name": "keyword.other.lean"}},
           "comment": "Binders to show in blue.",
           "patterns": [

--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -135,10 +135,20 @@
         { "match": "\\b([0-9]+|0([xX][0-9a-fA-F]+))\\b", "name": "constant.numeric.lean" },
 
         {
-          "begin": "\\b(?<!\\.)(fun|forall|assume|exists|λ)(?!\\.(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])", "end": ",|=>",
+          "begin": "\\b(?<!\\.)(forall|exists)(?!\\.?(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])", "end": ",|=>",
           "beginCaptures": {"0": {"name": "keyword.other.lean"}},
           "comment": "Binders to show in blue.",
           "patterns": [
+            { "include": "#comments" },
+            { "include": "#abbreviatedBinders" }
+          ]
+        },
+        {
+          "begin": "\\b(?<!\\.)((fun|assume)(?!\\.?(?![λΠΣ])[_a-zA-Zα-ωΑ-Ωϊ-ϻἀ-῾℀-⅏𝒜-𝖟0-9'ⁿ-₉ₐ-ₜᵢ-ᵪ])|λ)", "end": ",|=>",
+          "beginCaptures": {"0": {"name": "keyword.other.lean"}},
+          "comment": "Binders with pattern matching to show in blue.",
+          "patterns": [
+            { "begin": "⟨", "end": "⟩", "comment": "Do not attempt to parse within pattern matches for now." },
             { "include": "#comments" },
             { "include": "#abbreviatedBinders" }
           ]

--- a/syntaxes/lean.json
+++ b/syntaxes/lean.json
@@ -148,7 +148,10 @@
           "beginCaptures": {"0": {"name": "keyword.other.lean"}},
           "comment": "Binders with pattern matching to show in blue.",
           "patterns": [
-            { "begin": "⟨", "end": "⟩", "comment": "Do not attempt to parse within pattern matches for now." },
+            { "begin": "⟨", "end": "⟩", "comment": "Do not attempt to parse parameters within pattern matches for now.",
+              "patterns": [
+                { "include": "#expressions" }
+              ] },
             { "include": "#comments" },
             { "include": "#abbreviatedBinders" }
           ]


### PR DESCRIPTION
This fixes:

* Incorrect handling of `exists.elim` (note: github does not have the version with this bug yet)
* Incorrect handling of lambda with no space
* messy highlighting of pattern matches

Tested on this input:
```lean
#check (λ x ⟨e, f⟩ y, e : ℕ → ℕ × ℕ → ℕ → ℕ)
#check (fun x ⟨e, f⟩ y, e : ℕ → ℕ × ℕ → ℕ → ℕ)
#check (assume x ⟨e, f⟩ y, e : ℕ → ℕ × ℕ → ℕ → ℕ)

#check existse
#check exists.e
#check exists e, e

#check fune
#check fun.e
#check fun e, e

#check λe, e
```
This produces
![image](https://user-images.githubusercontent.com/425260/122795557-5b715680-d2b5-11eb-90b3-e947cdf2c130.png)

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/VSCode.20highlighting.20stopped/near/243387137)