### PR TITLE
fix: translate between utf16 code unit offsets (vscode) and codepoints (lean)

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -2,6 +2,7 @@ import { CompletionItem, CompletionItemKind, CompletionItemProvider,
     MarkdownString, Position, Range, TextDocument, workspace } from 'vscode';
 import { Server } from './server';
 import { isInputCompletion } from './util';
+import { CodePointPosition } from './utils/utf16Position';
 
 const keywords = [
     'theorem', 'lemma', 'axiom', 'axioms', 'variable', 'protected', 'private',
@@ -42,7 +43,8 @@ export class LeanCompletionItemProvider implements CompletionItemProvider {
             Promise<CompletionItem[]> {
         // TODO(gabriel): use LeanInputAbbreviator.active() instead
         if (!isInputCompletion(document, position)) {
-            const message = await this.server.complete(document.fileName, position.line + 1, position.character);
+            const codePointPosition = CodePointPosition.ofPosition(document, position);
+            const message = await this.server.complete(document.fileName, codePointPosition.line + 1, codePointPosition.character);
             const completions: CompletionItem[] = [];
             if (message.completions) {
                 for (const completion of message.completions) {

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -1,5 +1,6 @@
 import { Hover, HoverProvider, MarkdownString, Position, Range, TextDocument } from 'vscode';
 import { Server } from './server';
+import { CodePointPosition } from './utils/utf16Position';
 
 export class LeanHoverProvider implements HoverProvider {
     server: Server;
@@ -9,7 +10,8 @@ export class LeanHoverProvider implements HoverProvider {
     }
 
     async provideHover(document: TextDocument, position: Position): Promise<Hover> {
-        const response = await this.server.info(document.fileName, position.line + 1, position.character);
+        const codePointPosition = CodePointPosition.ofPosition(document, position);
+        const response = await this.server.info(document.fileName, codePointPosition.line + 1, codePointPosition.character);
         if (response.record) {
             const contents: MarkdownString[] = [];
             const name = response.record['full-id'] || response.record.text;
@@ -30,8 +32,8 @@ export class LeanHoverProvider implements HoverProvider {
                 contents.push(new MarkdownString()
                     .appendCodeblock(response.record.state, 'lean'));
             }
-            const pos = new Position(position.line - 1, position.character);
-            return new Hover(contents, new Range(pos, pos));
+            // const pos = new Position(position.line - 1, position.character);
+            return new Hover(contents, new Range(position, position));
         }
     }
 }

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -32,7 +32,6 @@ export class LeanHoverProvider implements HoverProvider {
                 contents.push(new MarkdownString()
                     .appendCodeblock(response.record.state, 'lean'));
             }
-            // const pos = new Position(position.line - 1, position.character);
             return new Hover(contents, new Range(position, position));
         }
     }

--- a/src/infoview.ts
+++ b/src/infoview.ts
@@ -294,7 +294,6 @@ export class InfoProvider implements Disposable {
     }
 
     private async revealEditorPosition(uri: Uri, line: number, column: number) {
-        const pos = new Position(line - 1, column);
         let editor = null;
         for (const e of window.visibleTextEditors) {
             if (e.document.uri.toString() === uri.toString()) {
@@ -307,6 +306,7 @@ export class InfoProvider implements Disposable {
             const td = await workspace.openTextDocument(uri);
             editor = await window.showTextDocument(td, c, false);
         }
+        const pos = new CodePointPosition(line - 1, column).toPosition(editor.document);
         editor.revealRange(new Range(pos, pos), TextEditorRevealType.InCenterIfOutsideViewport);
         editor.selection = new Selection(pos, pos);
         return;
@@ -318,9 +318,9 @@ export class InfoProvider implements Disposable {
         const endColumn = column;
         for (const editor of window.visibleTextEditors) {
             if (editor.document.uri.path === file_name) {
-                const pos = new Position(line - 1, column);
-                const endPos = new Position(endLine - 1, endColumn);
-                const range = new Range(pos, endPos);
+                const pos = new CodePointPosition(line - 1, column);
+                const endPos = new CodePointPosition(endLine - 1, endColumn);
+                const range = new Range(pos.toPosition(editor.document), endPos.toPosition(editor.document));
                 editor.setDecorations(this.hoverDecorationType, [range]);
             }
         }

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,18 +1,20 @@
-import { Location, Position, SymbolInformation, SymbolKind, Uri, WorkspaceSymbolProvider } from 'vscode';
+import { CancellationToken, Location, Position, ProviderResult, SymbolInformation, SymbolKind, Uri, workspace, WorkspaceSymbolProvider } from 'vscode';
 import { Server } from './server';
+import { CodePointPosition } from './utils/utf16Position';
 
 export class LeanWorkspaceSymbolProvider implements WorkspaceSymbolProvider {
     constructor(private server: Server) {}
 
     async provideWorkspaceSymbols(query: string): Promise<SymbolInformation[]> {
         const response = await this.server.search(query);
-        return response.results
+        return await Promise.all(response.results
             .filter((item) => item.source && item.source.file &&
                 item.source.line && item.source.column)
-            .map((item) => {
+            .map(async (item) => {
+                const document = await workspace.openTextDocument(Uri.file(item.source.file));
                 const loc = new Location(Uri.file(item.source.file),
-                    new Position(item.source.line - 1, item.source.column));
+                    new CodePointPosition(item.source.line - 1, item.source.column).toPosition(document));
                 return new SymbolInformation(item.text, SymbolKind.Function, item.type, loc);
-            });
+            }));
     }
 }

--- a/src/taskgutter.ts
+++ b/src/taskgutter.ts
@@ -51,6 +51,7 @@ export class LeanTaskMessages implements Disposable {
 
     constructor(server: Server) {
         this.collection = languages.createDiagnosticCollection('lean-tasks');
+        // TODO: Is it ok that `uupdateMsgs` returns a promise?
         this.subscriptions.push(server.statusChanged.on(
             (status) => this.updateMsgs(status)));
         this.subscriptions.push(workspace.onDidChangeConfiguration(() =>

--- a/src/utils/utf16Position.ts
+++ b/src/utils/utf16Position.ts
@@ -1,8 +1,12 @@
 import { Position, TextDocument } from 'vscode';
 
-// The server reports positions as unicode codepoints, but VSCode's API (and the javascript
-// runtime) measures things in UTF16 code _units_. It turns out that `...str` in javascript
-// splits a string into its codepoints, which is precisely what we want to count.
+/**
+ * The lean server reports positions as unicode codepoints, which matches what the VSCode editor
+ * shows to the user; but VSCode's API (and the javascript runtime) measures things in UTF16 code
+ * _units_ internally. This class converts between the two.
+ * 
+ * We impleemnt this using `...str` to split code units into codepoints.
+ */
 export class CodePointPosition {
     constructor(
         /**

--- a/src/utils/utf16Position.ts
+++ b/src/utils/utf16Position.ts
@@ -4,8 +4,10 @@ import { Position, TextDocument } from 'vscode';
  * The lean server reports positions as unicode codepoints, which matches what the VSCode editor
  * shows to the user; but VSCode's API (and the javascript runtime) measures things in UTF16 code
  * _units_ internally. This class converts between the two.
- * 
- * We impleemnt this using `...str` to split code units into codepoints.
+ *
+ * We implement this using `...str` to split code units into codepoints.
+ *
+ * Note that this does not deal with the lean server starting its line numbers at 1 and not zero.
  */
 export class CodePointPosition {
     constructor(

--- a/src/utils/utf16Position.ts
+++ b/src/utils/utf16Position.ts
@@ -1,0 +1,28 @@
+import { Position, TextDocument } from 'vscode';
+
+// The server reports positions as unicode codepoints, but VSCode's API (and the javascript
+// runtime) measures things in UTF16 code _units_. It turns out that `...str` in javascript
+// splits a string into its codepoints, which is precisely what we want to count.
+export class CodePointPosition {
+    constructor(
+        /**
+         * The zero-based line value.
+         */
+        readonly line: number, 
+        /**
+         * The zero-based character value, in unicode codepoints (not javascript UTF16 codewords!)
+         */
+        readonly character: number) {}
+
+    toPosition (t : TextDocument) : Position {
+        let lineStr = t.lineAt(new Position(this.line, 0)).text;
+        let fixedCol = [...lineStr].slice(0, this.character).join("").length;
+        return new Position(this.line, fixedCol);
+    }
+
+    public static ofPosition (t: TextDocument, p: Position) : CodePointPosition {
+        let lineStr = t.lineAt(p).text.slice(0, p.character);
+        return new CodePointPosition(p.line, [...lineStr].length);
+    }
+}
+

--- a/src/utils/utf16Position.ts
+++ b/src/utils/utf16Position.ts
@@ -8,20 +8,20 @@ export class CodePointPosition {
         /**
          * The zero-based line value.
          */
-        readonly line: number, 
+        readonly line: number,
         /**
          * The zero-based character value, in unicode codepoints (not javascript UTF16 codewords!)
          */
         readonly character: number) {}
 
     toPosition (t : TextDocument) : Position {
-        let lineStr = t.lineAt(new Position(this.line, 0)).text;
-        let fixedCol = [...lineStr].slice(0, this.character).join("").length;
+        const lineStr = t.lineAt(new Position(this.line, 0)).text;
+        const fixedCol = [...lineStr].slice(0, this.character).join('').length;
         return new Position(this.line, fixedCol);
     }
 
-    public static ofPosition (t: TextDocument, p: Position) : CodePointPosition {
-        let lineStr = t.lineAt(p).text.slice(0, p.character);
+    static ofPosition (t: TextDocument, p: Position) : CodePointPosition {
+        const lineStr = t.lineAt(p).text.slice(0, p.character);
         return new CodePointPosition(p.line, [...lineStr].length);
     }
 }


### PR DESCRIPTION
This testcase now draws the errors in the right place
```lean
example (𝒜𝒜𝒜𝒜𝒜𝒜𝒜𝒜𝒜𝒜𝒜𝒜 : nat) : ℕ := _ + _

example (AAAAAAAAAAAA : nat) : ℕ := _ + _
```

Also now working and previously broken:

* Hole positioning
* Infoview column numbers
* Autocomplete
* Goto definition
* Docstring hovers
* Try this (previously replaced the wrong text)
* `progressMessages` setting underlines, test-case:
  ```lean
  /-𝒜𝒜𝒜𝒜𝒜𝒜𝒜-/ #eval do tactic.sleep 1000
  /-𝒜𝒜𝒜𝒜𝒜𝒜𝒜-/ #eval do tactic.sleep 1000
  ```
Untested:

* `LeanWorkspaceSymbolProvider` (does the server even support this?)