### PR TITLE
Fix 'try this' in untitled windows

### DIFF
--- a/src/tacticsuggestions.ts
+++ b/src/tacticsuggestions.ts
@@ -42,7 +42,8 @@ export class TacticSuggestions implements Disposable, CodeActionProvider {
 
     private findTextEditor(fileName: string) {
         for (const textEditor of window.visibleTextEditors) {
-            if (textEditor.document.uri.toString() === Uri.file(fileName).toString()) {
+            // note we cannot compare URIs as the `Message` type doesn't contain them
+            if (textEditor.document.fileName === fileName) {
                 return textEditor;
             }
         }


### PR DESCRIPTION
This logic isn't perfect as there might be a file on the system called `Untitled 1`, but it's what we use throughout the rest of the extension anyway.