### PR TITLE
Do not do manual html escaping of react components

### DIFF
--- a/infoview/goal.tsx
+++ b/infoview/goal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { colorizeMessage, escapeHtml } from './util';
+import { colorizeMessage } from './util';
 import { ConfigContext } from './index';
 
 interface GoalProps {
@@ -23,7 +23,7 @@ export function Goal(props: GoalProps): JSX.Element {
                 return filt.match ? test : !test;
             }).join('\n');
     }
-    goalString = colorizeMessage(escapeHtml(goalString));
+    const goalElem = colorizeMessage(goalString);
     return <div>
         {reFilters.length !== 0 && <div className="fr">
             <label>filter: </label>
@@ -32,7 +32,7 @@ export function Goal(props: GoalProps): JSX.Element {
                 {reFilters.map((obj,i) => <option value={i}>{obj.name || `${obj.match ? 'show ' : 'hide '}/${obj.regex}/${obj.flags}`}</option>)}
             </select>
         </div>}
-        <pre className="font-code"  style={{whiteSpace: 'pre-wrap'}} dangerouslySetInnerHTML={{ __html: goalString }} />
+        <pre className="font-code"  style={{whiteSpace: 'pre-wrap'}}>{goalElem}</pre>
     </div>
 
 }

--- a/infoview/messages.tsx
+++ b/infoview/messages.tsx
@@ -1,4 +1,4 @@
-import { basename, escapeHtml, colorizeMessage } from './util';
+import { basename, escapeHtml, colorizeMessage, regexMap } from './util';
 import { Message } from 'lean-client-js-node';
 import * as React from 'react';
 import { Location, Config } from '../src/shared';
@@ -19,40 +19,23 @@ interface MessageViewProps {
     m: Message;
 }
 
-
-function regex_map<T>(regex: RegExp, s: string, f_no_match: (snm : string) => T, f_match: (m : RegExpExecArray) => T ) : T[] {
-    const r = new RegExp(regex);
-    const out = [];
-    let lastIdx = r.lastIndex;
-    let match : RegExpExecArray = null;
-    while ((match = r.exec(s)) !== null) {
-        const not_matched = s.slice(lastIdx, match.index);
-        if (not_matched) out.push(f_no_match(not_matched));
-        out.push(f_match(match));
-        lastIdx = r.lastIndex;
-    }
-    const final_non_match = s.slice(lastIdx);
-    if (final_non_match) out.push(final_non_match);
-    return out;
-}
-
-
 const MessageView = React.memo(({m}: MessageViewProps) => {
     const b = escapeHtml(basename(m.file_name));
     const l = m.pos_line; const c = m.pos_col;
     const loc: Location = {file_name: m.file_name, column: c, line: l}
     const shouldColorize = m.severity === 'error';
 
-    const text_nodes = regex_map(trythis.regexGM, m.text,
+    const text_nodes = regexMap(trythis.regexGM, m.text,
         (text) => {
             text = escapeHtml(text);
             text = shouldColorize ? colorizeMessage(text) : text;
             // TODO: avoid this span tag somehow
             return <span dangerouslySetInnerHTML={{ __html: text }}></span>;
         },
-        (tactic) => {
-            const command = encodeURI('command:_lean.pasteTacticSuggestion?' + JSON.stringify([m, tactic[0]]));
-            return <>{trythis.magicWord}<a className="link" href={command} title={tactic[0]}>{tactic[0]}</a></>
+        (match) => {
+            const [_, tactic] = match;
+            const command = encodeURI('command:_lean.pasteTacticSuggestion?' + JSON.stringify([m, tactic]));
+            return <>{trythis.magicWord}<a className="link" href={command} title={tactic}>{tactic}</a></>
         });
 
     const title = `${b}:${l}:${c}`;

--- a/infoview/messages.tsx
+++ b/infoview/messages.tsx
@@ -1,4 +1,4 @@
-import { basename, escapeHtml, colorizeMessage, regexMap } from './util';
+import { basename, colorizeMessage, regexMap } from './util';
 import { Message } from 'lean-client-js-node';
 import * as React from 'react';
 import { Location, Config } from '../src/shared';
@@ -26,12 +26,7 @@ const MessageView = React.memo(({m}: MessageViewProps) => {
     const shouldColorize = m.severity === 'error';
 
     const text_nodes = regexMap(trythis.regexGM, m.text,
-        (text) => {
-            text = escapeHtml(text);
-            text = shouldColorize ? colorizeMessage(text) : text;
-            // TODO: avoid this span tag somehow
-            return <span dangerouslySetInnerHTML={{ __html: text }}></span>;
-        },
+        (text) => shouldColorize ? colorizeMessage(text) : <>{text}</>,
         (match) => {
             const [_, tactic] = match;
             const command = encodeURI('command:_lean.pasteTacticSuggestion?' + JSON.stringify([m, tactic]));

--- a/infoview/messages.tsx
+++ b/infoview/messages.tsx
@@ -20,7 +20,7 @@ interface MessageViewProps {
 }
 
 const MessageView = React.memo(({m}: MessageViewProps) => {
-    const b = escapeHtml(basename(m.file_name));
+    const b = basename(m.file_name);
     const l = m.pos_line; const c = m.pos_col;
     const loc: Location = {file_name: m.file_name, column: c, line: l}
     const shouldColorize = m.severity === 'error';

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -14,6 +14,7 @@ export function escapeHtml(s: string): string {
 /// Split a string by a regex, executing `f_no_match` on the pieces which don't match, `f_match` on the pieces which do,
 /// and concatenating the results into an array.
 export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string) => T, f_match: (m : RegExpExecArray) => T ) : T[] {
+    // copy the regex to reset the position information
     const r = new RegExp(regex);
     const out = [];
     let lastIdx = r.lastIndex;
@@ -26,7 +27,7 @@ export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string)
         if (!r.global) break;
     }
     const final_non_match = s.slice(lastIdx);
-    if (final_non_match) out.push(final_non_match);
+    if (final_non_match) out.push(f_no_match(final_non_match));
     return out;
 }
 

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -11,6 +11,25 @@ export function escapeHtml(s: string): string {
         .replace(/'/g, '&#039;');
 }
 
+/// Split a string by a regex, executing `f_no_match` on the pieces which don't match, `f_match` on the pieces which do,
+/// and concatenating the results into an array.
+export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string) => T, f_match: (m : RegExpExecArray) => T ) : T[] {
+    const r = new RegExp(regex);
+    const out = [];
+    let lastIdx = r.lastIndex;
+    let match = null;
+    while ((match = r.exec(s)) !== null) {
+        const not_matched = s.slice(lastIdx, match.index);
+        if (not_matched) out.push(f_no_match(not_matched));
+        out.push(f_match(match));
+        lastIdx = r.lastIndex;
+        if (!r.global) break;
+    }
+    const final_non_match = s.slice(lastIdx);
+    if (final_non_match) out.push(final_non_match);
+    return out;
+}
+
 export function colorizeMessage(goal: string): string {
     return goal
         .replace(/^([|⊢]) /mg, '<strong class="goal-vdash">$1</strong> ')

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Event } from 'lean-client-js-core';
 
-/// Split a string by a regex, executing `f_no_match` on the pieces which don't match, `f_match` on the pieces which do,
-/// and concatenating the results into an array.
+/** Split a string by a regex, executing `f_no_match` on the pieces which don't match, `f_match` on the pieces which do,
+and concatenating the results into an array. */
 export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string) => T, f_match: (m : RegExpExecArray) => T ) : T[] {
     // copy the regex to reset the position information
     const r = new RegExp(regex);

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -22,24 +22,26 @@ export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string)
 }
 
 export function colorizeMessage(goal: string): JSX.Element {
-    // TODO: do this processing without going via an HTML string
-
-    // https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
-    let raw_html = goal
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-    raw_html = raw_html
-        .replace(/^([|⊢]) /mg, '<strong class="goal-vdash">$1</strong> ')
-        .replace(/^(\d+ goals|1 goal)/mg, '<strong class="goal-goals">$1</strong>')
-        .replace(/^(context|state):/mg, '<strong class="goal-goals">$1</strong>:')
-        .replace(/^(case) /mg, '<strong class="goal-case">$1</strong> ')
-        .replace(/^([^:\n< ][^:\n⊢{[(⦃]*) :/mg, '<strong class="goal-hyp">$1</strong> :');
-
-    // TODO: avoid this span tag somehow
-    return <span dangerouslySetInnerHTML={{ __html: raw_html }}></span>;
+    // `replace(r, match)(cont)(s)` replaces `r` with `match` in `s`, and runs `cont` on
+    // non-matches.
+    const replace = <T,>(r: RegExp, match: (s : string) => T) =>
+                        (cont: (s : string) => T[]) =>
+                        (s : string) : T[] => {
+        const results = regexMap<T[]>(r, s, cont, m => [match(m[1])]);
+        return Array.prototype.concat(...results);
+    }
+    const pipeline = [
+        replace(/^([|⊢]) /mg,                  x => <strong className="goal-vdash">{x}&nbsp;</strong>),
+        replace(/^(\d+ goals|1 goal)/mg,       x => <strong className="goal-goals">{x}</strong>),
+        replace(/^(context|state):/mg,         x => <><strong className="goal-goals">{x}</strong>:</>),
+        replace(/^(case) /mg,                  x => <><strong className="goal-case">{x}</strong>&nbsp;</> ),
+        replace(/^([^:\n< ][^:\n⊢{[(⦃]*) :/mg, x => <><strong className="goal-hyp">{x}</strong> :</>),
+    ]
+    let replacer = (s : string) => [<>{s}</>];
+    for (const f of pipeline.reverse()) {
+        replacer = f(replacer);
+    }
+    return <>{replacer(goal)}</>;
 }
 
 export function basename(path: string): string { return path.split(/[\\/]/).pop(); }

--- a/infoview/util.tsx
+++ b/infoview/util.tsx
@@ -1,16 +1,6 @@
 import * as React from 'react';
 import { Event } from 'lean-client-js-core';
 
-// https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
-export function escapeHtml(s: string): string {
-    return s
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;');
-}
-
 /// Split a string by a regex, executing `f_no_match` on the pieces which don't match, `f_match` on the pieces which do,
 /// and concatenating the results into an array.
 export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string) => T, f_match: (m : RegExpExecArray) => T ) : T[] {
@@ -31,13 +21,25 @@ export function regexMap<T>(regex: RegExp, s: string, f_no_match: (snm : string)
     return out;
 }
 
-export function colorizeMessage(goal: string): string {
-    return goal
+export function colorizeMessage(goal: string): JSX.Element {
+    // TODO: do this processing without going via an HTML string
+
+    // https://stackoverflow.com/questions/6234773/can-i-escape-html-special-chars-in-javascript
+    let raw_html = goal
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+    raw_html = raw_html
         .replace(/^([|⊢]) /mg, '<strong class="goal-vdash">$1</strong> ')
         .replace(/^(\d+ goals|1 goal)/mg, '<strong class="goal-goals">$1</strong>')
         .replace(/^(context|state):/mg, '<strong class="goal-goals">$1</strong>:')
         .replace(/^(case) /mg, '<strong class="goal-case">$1</strong> ')
         .replace(/^([^:\n< ][^:\n⊢{[(⦃]*) :/mg, '<strong class="goal-hyp">$1</strong> :');
+
+    // TODO: avoid this span tag somehow
+    return <span dangerouslySetInnerHTML={{ __html: raw_html }}></span>;
 }
 
 export function basename(path: string): string { return path.split(/[\\/]/).pop(); }


### PR DESCRIPTION
This attempts to fix #308. Rather than trying to assemble a string with correct HTML escaping and then have it be parsed to DOM nodes, we construct the dom node directly.

The previous parsing was broken, because in essence vscode tries to run ` JSON.parse (htmlParse (jSON.stringify (htmlEscape x)))`, and the encoders and decoders do not commute.

The goal parser still uses the escape-mangle-parser approach, but that's slightly more work to rewrite in a principled way.
At any rate, it's not broken in the same way as no json-encoding is involved there.

This also removes some weird filename escaping that would result in filenames containing `<>` showing up with `&lt;&gt;` in the goal view.