### PR TITLE
Correct the symbol for perpendicular

### DIFF
--- a/src/abbreviation/abbreviations.json
+++ b/src/abbreviation/abbreviations.json
@@ -546,7 +546,7 @@
     "parallel": "∥",
     "pa": "▰",
     "pm": "±",
-    "perp": "⊥",
+    "perp": "⟂",
     "^perp": "ᗮ",
     "permil": "‰",
     "per": "⅌",


### PR DESCRIPTION
Unicode has two separate symbols for "up tack" (ie `has_bot.bot`) and "perpendicular" (not yet used in mathlib). Having `\perp` produce the former is confusing.