### PR TITLE
Add the two-sided abbreviation for <<>>

### DIFF
--- a/src/abbreviation/abbreviations.json
+++ b/src/abbreviation/abbreviations.json
@@ -9,6 +9,7 @@
     "()": "($CURSOR)",
     "()_": "($CURSOR)_",
     "([])'": "⟮$CURSOR⟯",
+    "<<>>": "⟪$CURSOR⟫",
     "f<>": "‹$CURSOR›",
     "f<<>>": "«$CURSOR»",
     "[--]": "⁅$CURSOR⁆",


### PR DESCRIPTION
(Used for e.g. inner products in mathlib)